### PR TITLE
new Activity ValuedParam

### DIFF
--- a/src/Components.py
+++ b/src/Components.py
@@ -511,9 +511,13 @@ class Interaction(Base):
       @ In, refs, dict, resource cross-reference objects
       @ Out, None
     """
+    # connect references to ValuedParams (Placeholder objects)
     for attr, obj in refs.items():
       valued_param = self._crossrefs[attr]
       valued_param.set_object(obj)
+    # perform crosscheck that VPs have what they need
+    for attr, vp in self.get_crossrefs().items():
+      vp.crosscheck(self)
 
   def get_inputs(self):
     """

--- a/src/Economics.py
+++ b/src/Economics.py
@@ -299,24 +299,24 @@ class CashFlow:
 
     descr = r"""indicates the main driver for this CashFlow, such as the number of units sold
             or the size of the constructed unit. Corresponds to $D$ in the CashFlow equation."""
-    driver = ValuedParams.factory.make_input_specs('driver', descr=descr)
+    driver = ValuedParams.factory.make_input_specs('driver', descr=descr, kind='post-dispatch')
     cf.addSub(driver)
 
     descr = r"""indicates the cash value of the reference number of units sold.
             corresponds to $\alpha$ in the CashFlow equation. If \xmlNode{reference_driver}
             is 1, then this is the price-per-unit for the CashFlow."""
-    reference_price = ValuedParams.factory.make_input_specs('reference_price', descr=descr)
+    reference_price = ValuedParams.factory.make_input_specs('reference_price', descr=descr, kind='post-dispatch')
     cf.addSub(reference_price)
 
     descr = r"""determines the number of units sold to which the \xmlNode{reference_price}
             refers. Corresponds to $\prime D$ in the CashFlow equation. """
-    reference_driver = ValuedParams.factory.make_input_specs('reference_driver', descr=descr)
+    reference_driver = ValuedParams.factory.make_input_specs('reference_driver', descr=descr, kind='post-dispatch')
     cf.addSub(reference_driver)
 
     descr = r"""determines the scaling factor for this CashFlow. Corresponds to $x$ in the CashFlow
             equation. If $x$ is less than one, the per-unit price decreases as the units sold increases
             above the \xmlNode{reference_driver}, and vice versa."""
-    x = ValuedParams.factory.make_input_specs('scaling_factor_x', descr=descr)
+    x = ValuedParams.factory.make_input_specs('scaling_factor_x', descr=descr, kind='post-dispatch')
     cf.addSub(x)
 
     depreciate = InputData.parameterInputFactory('depreciate', contentType=InputTypes.IntegerType)

--- a/src/Economics.py
+++ b/src/Economics.py
@@ -170,11 +170,16 @@ class CashFlowGroup:
       @ In, refs, dict, reference entities
       @ Out, None
     """
+    # set up pointers
     for cf in list(refs.keys()):
       for try_match in self._cash_flows:
         if try_match == cf:
           try_match.set_crossrefs(refs.pop(try_match))
           break
+      else:
+        cf.set_crossrefs({})
+    # perform checks
+
 
   #######
   # API #
@@ -352,7 +357,6 @@ class CashFlow:
     self._signals = set()     # variable values needed for this cash flow
     self._crossrefs = defaultdict(dict)
 
-
   def read_input(self, item):
     """
       Sets settings from input file
@@ -463,9 +467,13 @@ class CashFlow:
       @ In, refs, dict, cross referenced entities
       @ Out, None
     """
+    # set up pointers
     for attr, obj in refs.items():
       valued_param = self._crossrefs[attr]
       valued_param.set_object(obj)
+    # check on VP setup
+    for attr, vp in self._crossrefs.items():
+      vp.crosscheck(self._component.get_interaction())
 
   def evaluate_cost(self, activity, values_dict):
     """

--- a/src/ValuedParamHandler.py
+++ b/src/ValuedParamHandler.py
@@ -118,6 +118,14 @@ class ValuedParamHandler(MessageUser):
                        f'to define its value source, but none was found! Options include: {knownVPs}')
     return signal
 
+  def crosscheck(self, interaction):
+    """
+      Perform checks to make sure VP is set up correctly.
+      @ In, interaction, Component.Interaction, HERON Interaction that "owns" this VP
+      @ Out, None (error raised if not correct)
+    """
+    self._vp.crosscheck(interaction)
+
   def get_source(self):
     """
       Access the source type and name of the VP

--- a/src/ValuedParamHandler.py
+++ b/src/ValuedParamHandler.py
@@ -62,6 +62,15 @@ class ValuedParamHandler(MessageUser):
     self._growth_val = None  # used to grow the value year-by-year
     self._growth_mode = None # mode for growth (e.g. exponenetial, linear)
 
+  def __repr__(self):
+    """
+      String representation of this Handler and its VP
+      @ In, None
+      @ Out, repr, str, string representation
+    """
+    msg = f'<ValuedParam name: "{self.name}" type: "{self.type}">'
+    return msg
+
   @property
   def type(self):
     """

--- a/src/ValuedParams/Activity.py
+++ b/src/ValuedParams/Activity.py
@@ -1,0 +1,77 @@
+
+# Copyright 2020, Battelle Energy Alliance, LLC
+# ALL RIGHTS RESERVED
+"""
+  Defines the ValuedParam entity.
+  These are objects that need to return values, but come from
+  a wide variety of different sources.
+"""
+from .ValuedParam import ValuedParam, InputData, InputTypes
+
+# class for values based on dispatch activity
+class Activity(ValuedParam):
+  """
+    Represents a ValuedParam that takes values from dispatching activity
+  """
+  # these types represent values that do not need to be evaluated at run time, as they are determined.
+  @classmethod
+  def get_input_specs(cls):
+    """
+      Template for parameters that can take a scalar, an ARMA history, or a function
+      @ In, None
+      @ Out, spec, InputData, value-based spec
+    """
+    spec = InputData.parameterInputFactory('activity', contentType=InputTypes.StringType,
+        descr=r"""indicates that this value will be taken from the dispatched activity of this component.
+              The value of this node should be the name of a resource that this component
+              either produces or consumes. Note the sign of the activity by default will be negative
+              for consumed resources and positive for produced resources.""")
+    return spec
+
+  def __init__(self):
+    """
+      Constructor.
+      @ In, None
+      @ Out, None
+    """
+    super().__init__()
+    self._var_name = None # name of the variable within the synth hist
+    self._source_kind = 'activity'
+
+  def read(self, comp_name, spec, mode, alias_dict=None):
+    """
+      Used to read valued param from XML input
+      @ In, comp_name, str, name of component that this valued param will be attached to; only used for print messages
+      @ In, spec, InputData params, input specifications
+      @ In, mode, type of simulation calculation
+      @ In, alias_dict, dict, optional, aliases to use for variable naming
+      @ Out, needs, list, signals needed to evaluate this ValuedParam at runtime
+    """
+    super().read(comp_name, spec, mode, alias_dict=None)
+    # aliases get used to convert variable names, notably for the cashflow's "capacity"
+    if alias_dict is None:
+      alias_dict = {}
+    self._resource = spec.value
+    return []
+
+  def evaluate(self, inputs, target_var=None, aliases=None):
+    """
+      Evaluate this ValuedParam, wherever it gets its data from
+      @ In, inputs, dict, stuff from RAVEN, particularly including the keys 'meta' and 'raven_vars'
+      @ In, target_var, str, optional, requested outgoing variable name if not None
+      @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ Out, value, dict, dictionary of resulting evaluation as {vars: vals}
+      @ Out, meta, dict, dictionary of meta (possibly changed during evaluation)
+    """
+    if aliases is None:
+      aliases = {}
+    # set the outgoing name for the evaluation results
+    key = self._var_name if not target_var else target_var
+    # allow aliasing of complex variable names
+    var_name = aliases.get(self._var_name, self._var_name)
+    try:
+      value = inputs['HERON']['activity'][self._resource]
+    except KeyError as e:
+      self.raiseAnError(RuntimeError, f'Resource "{self._resource}" was not found among those produced and ' +
+                        'consumed by this component!')
+    return {key: value}, inputs

--- a/src/ValuedParams/Activity.py
+++ b/src/ValuedParams/Activity.py
@@ -52,6 +52,7 @@ class Activity(ValuedParam):
     if alias_dict is None:
       alias_dict = {}
     self._resource = spec.value
+    # FIXME how to confirm this component actually produces/consumes/stores this resource??
     return []
 
   def evaluate(self, inputs, target_var=None, aliases=None):

--- a/src/ValuedParams/Factory.py
+++ b/src/ValuedParams/Factory.py
@@ -10,6 +10,7 @@ from .Function import Function
 from .Parametric import Parametric, FixedValue, OptBounds, SweepValues
 from .Linear import Linear
 from .Variable import Variable
+from .Activity import Activity
 
 class ValuedParamFactory(EntityFactory):
   """
@@ -61,17 +62,22 @@ factory.registerType('variable', Variable)
 # frequent revaluation
 factory.registerType('ARMA', SyntheticHistory)
 factory.registerType('Function', Function)
+factory.registerType('activity', Activity)
 # ratios, transfers
 factory.registerType('linear', Linear)
+# TODO add: ROM
+
 # TODO are transfer functions and valued evaluations really the same creature?
-# TODO add: activity, ROM
 
 # map of "kinds" of ValuedParams to the default acceptable ValuedParam types
-allowable = {
-  # transfer functions, such as producing components' transfer functions
-  'transfer': ['linear', 'Function'],
-  # single evaluations, like cashflow prices and component capacities
-  'singular': ['fixed_value', 'sweep_values', 'opt_bounds', 'variable', 'ARMA', 'Function'],
-  # all
-  'all': list(factory.knownTypes()),
-}
+allowable = {}
+# transfer functions, such as producing components' transfer functions
+allowable['transfer'] = ['linear', 'Function']
+# single evaluations, like cashflow prices and component capacities
+allowable['singular'] = ['fixed_value', 'sweep_values', 'opt_bounds', 'variable',
+               'ARMA', 'Function']
+# evaluations available only after dispatch (e.g. for economics)
+## for example, we can't base a capacity on the dispatch activity ... right?
+allowable['post-dispatch'] = allowable['singular'] + ['activity']
+# all
+allowable['all'] = list(factory.knownTypes())

--- a/src/ValuedParams/ValuedParam.py
+++ b/src/ValuedParams/ValuedParam.py
@@ -61,6 +61,14 @@ class ValuedParam(MessageUser):
     # base implementation doesn't indicate any source/signal, so we return an empty list
     return []
 
+  def crosscheck(self, interaction):
+    """
+      Allows for post-reading, post-crossref checking to make sure everything is in place.
+      @ In, interaction, HERON.Component.Interaction, interaction that "owns" this VP
+      @ Out, None
+    """
+    pass # optional, use in subclasses as needed
+
   def get_source(self):
     """
       Accessor for the source type and name of this valued param

--- a/src/input_loader.py
+++ b/src/input_loader.py
@@ -86,6 +86,7 @@ def parse(xml, loc, messageHandler):
       for attr, info in i_info.items():
         kind, name = info.get_source()
         # if not looking for a DataGenerator placeholder, then nothing more to do
+        # if using "activity", also nothing to do
         if kind not in ['Function', 'ARMA']:
           continue
         # find it
@@ -94,7 +95,7 @@ def parse(xml, loc, messageHandler):
             found[interaction][attr] = source
             break
         else:
-          raise IOError('Requested source "{}" for component "{}" was not found!'.format(name, comp.name))
+          raise IOError(f'Requested source "{name}" for component "{comp.name}" was not found!')
     comp.set_crossrefs(found)
 
   # then do pre-writing initialization

--- a/tests/integration_tests/workflows/production_flex/heron_input.xml
+++ b/tests/integration_tests/workflows/production_flex/heron_input.xml
@@ -60,22 +60,12 @@
       </produces>
       <economics>
         <lifetime>27</lifetime>
-        <!--<CashFlow name="var_om" type="repeating" taxable='True' inflation='none' mult_target='False'>
-          <driver>
-            <resource>electricity</resource>
-            <Function method="steam_consume">transfers</Function>
-          </driver>
-          <reference_price>
-            <fixed_value>0.01</fixed_value>
-          </reference_price>
-        </CashFlow>-->
       </economics>
     </Component>
 
     <Component name="electr_market">
       <demands resource="electricity" dispatch="dependent"><!---->
         <capacity>
-          <!-- <fixed_value>-2</fixed_value> -->
           <fixed_value>-2</fixed_value>
         </capacity>
       </demands>
@@ -83,7 +73,7 @@
         <lifetime>30</lifetime>
         <CashFlow name="e_sales" type="repeating" taxable='True' inflation='none' mult_target='False'>
           <driver>
-            <Function method="electric_consume">transfers</Function>
+            <activity>electricity</activity>
             <multiplier>-1</multiplier>
           </driver>
           <reference_price>
@@ -92,12 +82,6 @@
         </CashFlow>
       </economics>
     </Component>
-
-    <!-- design notes
-    add a <resource> node for at least CashFlow drivers
-    add multiplier and absolute value options for manipulating entries
-    maybe disallow <linear> and <resource> except for applicable ValuedParams?
-    -->
 
     <Component name="electr_flex">
       <demands resource="electricity" dispatch="dependent">
@@ -109,6 +93,8 @@
         <lifetime>30</lifetime>
         <CashFlow name="e_sales" type="repeating" taxable='True' inflation='none' mult_target='False'>
           <driver>
+            <!-- NOTE this could be activity.electricity as with electr_market,
+                 but we show how to use the Function here for variety. -->
             <Function method="electric_consume">transfers</Function>
             <multiplier>-1</multiplier>
           </driver>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #84 

##### What are the significant changes in functionality due to this change request?
Adds the `<activity>` node, which does a simple lookup of dispatch activity for the associated component.

For example, if a `<Produces>` component consumes `steam` to make `electricity`, a `CashFlow` might include the driver:
```xml
<driver>
  <activity>steam</activity>
  <multiplier>-1</multiplier>
</driver>
```
to suggest a cashflow of -1 * amount of steam consumed (negative * negative makes positive).

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [ ] 4. Automated Tests should pass.
- [ ] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [ ] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

