### PR TITLE
Adds opt plotter for opt mode

### DIFF
--- a/templates/outer.xml
+++ b/templates/outer.xml
@@ -25,6 +25,10 @@
       <SolutionExport class='DataObjects' type='PointSet'        >opt_soln</SolutionExport>
       <Output         class='OutStreams'  type='Print'           >opt_soln</Output>
     </MultiRun>
+    <IOStep name="plot">
+      <Input class="DataObjects" type="PointSet">opt_soln</Input>
+      <Output class='OutStreams' type='Plot'>opt_path</Output>
+    </IOStep>
   </Steps>
 
   <VariableGroups>
@@ -113,5 +117,9 @@
       <source>opt_soln</source>
       <clusterLabel>trajID</clusterLabel>
     </Print>
+    <Plot name="opt_path" subType="OptPath">
+      <source>opt_soln</source>
+      <vars>GRO_capacities, mean_NPV</vars>
+    </Plot>
   </OutStreams>
 </Simulation>

--- a/templates/template_driver.py
+++ b/templates/template_driver.py
@@ -229,7 +229,7 @@ class Template(TemplateBase):
     elif case.get_mode() == 'sweep':
       run_info.find('Sequence').text = 'sweep'
     elif case.get_mode() == 'opt':
-      run_info.find('Sequence').text = 'optimize'
+      run_info.find('Sequence').text = 'optimize, plot'
 
   def _modify_outer_vargroups(self, template, case, components, sources):
     """
@@ -465,7 +465,7 @@ class Template(TemplateBase):
     steps = template.find('Steps')
     # clear out optimization if not used
     if case.get_mode() == 'sweep' or case.debug['enabled']:
-      self._remove_by_name(steps, ['optimize'])
+      self._remove_by_name(steps, ['optimize', 'plot'])
     elif case.get_mode() == 'opt':
       self._remove_by_name(steps, ['sweep'])
     if case.debug['enabled']:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #93 

##### What are the significant changes in functionality due to this change request?
Adds an optimization path plotter to `opt` mode cases.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

