### PR TITLE
Adding netcdf-csv flag

### DIFF
--- a/src/Cases.py
+++ b/src/Cases.py
@@ -338,7 +338,7 @@ class Case(Base):
     }
 
     self.data_handling = {     # data handling options
-      'inner_outer_data': 'netcdf', # how to pass inner data to outer (csv, netcdf)
+      'inner_to_outer': 'netcdf', # how to pass inner data to outer (csv, netcdf)
     }
 
     self._time_discretization = None # (start, end, number) for constructing time discretization, same as argument to np.linspace

--- a/templates/template_driver.py
+++ b/templates/template_driver.py
@@ -436,6 +436,13 @@ class Template(TemplateBase, Base):
     if case.debug['enabled']:
       raven.find('outputDatabase').text = 'disp_full'
 
+    # data handling: inner to outer data format
+    if case.data_handling['inner_to_outer'] == 'csv':
+      # swap the outputDatabase to outputExportOutStreams
+      output_node = template.find('Models').find('Code').find('outputDatabase')
+      output_node.tag = 'outputExportOutStreams'
+      # no need to change name, as database and outstream have the same name
+
 
   def _modify_outer_outstreams(self, template, case, components, sources):
     """
@@ -684,6 +691,7 @@ class Template(TemplateBase, Base):
     self._modify_inner_caselabels(template, case)
     self._modify_inner_time_vars(template, case)
     self._modify_inner_optimization_settings(template, case)
+    self._modify_inner_data_handling(template, case)
     if case.debug['enabled']:
       self._modify_inner_debug(template, case, components)
     # TODO modify based on resources ... should only need if units produce multiple things, right?
@@ -936,6 +944,24 @@ class Template(TemplateBase, Base):
             if str(int(case._optimization_settings['metric']['percent'])) not in ['5', '95']:
               # update attribute
               subnode.attrib['percent'] = str(case._optimization_settings['metric']['percent'])
+
+  def _modify_inner_data_handling(self, template, case):
+    """
+      Modifies template to include data handling options
+      @ In, template, xml.etree.ElementTree.Element, root of XML to modify
+      @ In, case, HERON Case, defining Case instance
+      @ Out, None
+    """
+    # inner to outer
+    ## default is netCDF, and is how the templates are already set up
+    if case.data_handling['inner_to_outer'] == 'csv':
+      # change the output IOStep outstream to do CSV instead of database
+      print(
+      template.find('Steps').find(".//IOStep[@name='database']")
+      )
+      db = template.find('Steps').find('.//IOStep[@name="database"]').find('.//Output[@class="Databases"]')
+      db.attrib.update({'class': 'OutStreams', 'type': 'Print'})
+      # the database and outstream print have the same name, so don't need to change text of node
 
 
   ##### CASHFLOW #####

--- a/tests/integration_tests/mechanics/optimization_settings/heron_input.xml
+++ b/tests/integration_tests/mechanics/optimization_settings/heron_input.xml
@@ -35,6 +35,9 @@
       <metric>valueAtRisk</metric>
       <type>min</type>
     </optimization_settings>
+    <data_handling>
+      <inner_to_outer>csv</inner_to_outer>
+    </data_handling>
   </Case>
 
   <Components>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #148 

##### What are the significant changes in functionality due to this change request?
Adds a flag in `Cases.data_handling.inner_to_outer` that allows a user to specify `netcdf` (default) or `csv`, which determines in what format data will be passed from the inner run to the outer run.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

