### PR TITLE
Changed HERON path variable in collect_tex.py

### DIFF
--- a/doc/user_manual/script/collect_tex.py
+++ b/doc/user_manual/script/collect_tex.py
@@ -7,12 +7,12 @@
 import os
 import sys
 
-heron_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', 'src'))
+heron_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..'))
 build_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'build'))
 src_path = os.path.abspath(os.path.join(build_path, '..', 'src'))
 
 sys.path.append(heron_path)
-import Cases, Components, Placeholders
+from HERON.src import Cases, Components, Placeholders
 # import _utils as hutils
 # framework_path = hutils.get_raven_loc()
 # sys.path.append(framework_path)

--- a/doc/user_manual/script/collect_tex.py
+++ b/doc/user_manual/script/collect_tex.py
@@ -13,10 +13,6 @@ src_path = os.path.abspath(os.path.join(build_path, '..', 'src'))
 
 sys.path.append(heron_path)
 from HERON.src import Cases, Components, Placeholders
-# import _utils as hutils
-# framework_path = hutils.get_raven_loc()
-# sys.path.append(framework_path)
-# from utils import InputData
 
 specs_to_load = {'Cases': ['Case'],
                  'Components': ['Component'],


### PR DESCRIPTION
Changed heron_path in collect_tex.py so that the HERON module is found when compiling the documentation via make_docs.sh.
--------
Pull Request Description
--------
##### What issue does this change request address?
#184 

##### What are the significant changes in functionality due to this change request?
No changes in functionality.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

