### PR TITLE
Dispatches dependency

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <main>
-    <dill/>
+    <dill>0.3.5</dill>
     <dispatches source='pip' optional='True'>1.0</dispatches>
     <pyomo source='forge'/>
     <pyutilib source='forge'/>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -1,7 +1,7 @@
 <dependencies>
   <main>
     <dill/>
-    <dispatches source='pip'>1.0</dispatches>
+    <dispatches source='pip' optional='True'>1.0</dispatches>
     <pyomo source='forge'/>
     <pyutilib source='forge'/>
     <glpk source='forge' skip_check='True'/>

--- a/src/Herd.py
+++ b/src/Herd.py
@@ -24,15 +24,18 @@ except ModuleNotFoundError:
 from ravenframework.utils import xmlUtils
 from ravenframework.ROMExternal import ROMLoader
 
-# Nuclear flowsheet function imports
+
 # NOTE: these paths will change for next DISPATCHES release
-from dispatches.models.nuclear_case.flowsheets.nuclear_flowsheet import build_ne_flowsheet
-from dispatches.models.nuclear_case.flowsheets.nuclear_flowsheet import fix_dof_and_initialize
-
-# Import function for the construction of the multiperiod model
-from dispatches.models.nuclear_case.flowsheets.multiperiod import build_multiperiod_design
-
-from idaes.core.solvers import get_solver
+try:
+  # Nuclear flowsheet function imports
+  from dispatches.models.nuclear_case.flowsheets.nuclear_flowsheet import (build_ne_flowsheet,
+                                                                           fix_dof_and_initialize)
+  # Import function for the construction of the multiperiod model
+  from dispatches.models.nuclear_case.flowsheets.multiperiod import build_multiperiod_design
+  from idaes.core.solvers import get_solver
+except ModuleNotFoundError:
+  print("DISPATCHES has not been found in current conda environment. This is only needed when "+
+        "running the DISPATCHES workflow through HERD.")
 
 # append path with RAVEN location
 path_to_raven = hutils.get_raven_loc()

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError:
 from HERON.src import input_loader
 from HERON.src.base import Base
 from HERON.src.Moped import MOPED
-from HERON.src import Herd
+from HERON.src.Herd import HERD
 
 from ravenframework.MessageHandler import MessageHandler
 
@@ -122,16 +122,24 @@ class HERON(Base):
       @ In, None
       @ Out, None
     """
+    # checking to see if DISPATCHES is properly installed
+    try:
+      import dispatches.models as tmp_lib
+      del tmp_lib
+    except ModuleNotFoundError as mnferr:
+      raise IOError('DISPATCHES has not been found in current conda environment.' +
+                    'Please re-install the conda environment from RAVEN using the ' +
+                    '--optional flag.') from mnferr
     case = self._case
     components = self._components
     sources = self._sources
     assert case is not None and components is not None and sources is not None
-    dispatches = Herd.HERD()
+    herd = HERD()
     print("*******************************************************************************")
     print("HERON is Running DISPATCHES")
     print("*******************************************************************************")
-    dispatches.setInitialParams(case, components, sources)
-    dispatches.run()
+    herd.setInitialParams(case, components, sources)
+    herd.run()
 
 def main():
   """

--- a/tests/integration_tests/workflows/HERD/nuclearCase_Sine/tests
+++ b/tests/integration_tests/workflows/HERD/nuclearCase_Sine/tests
@@ -2,6 +2,7 @@
  [./NuclearCaseSine]
   type = HeronMoped
   input = dispatches_sine_input.xml
+  required_libraries = 'dispatches'
   # prereq = arma
   [./csv]
     type = OrderedCSV

--- a/tests/integration_tests/workflows/HERD/nuclearCase_notebook_match/tests
+++ b/tests/integration_tests/workflows/HERD/nuclearCase_notebook_match/tests
@@ -3,6 +3,8 @@
   type = HeronMoped
   input = dispatches_input.xml
   max_time = 600
+  required_libraries = 'dispatches'
+  heavy = true
   [./csv]
     type = OrderedCSV
     output = 'opt_solution__nuclearCase_notebook_match.csv'


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#221 

##### What are the significant changes in functionality due to this change request?
DISPATCHES is now an optional dependency. It will only be installed in the conda environment if requested (with the --optional flag).  No changes to other standard or MOPED workflows. If DISPATCHES workflow is attempted from an XML input, an error will alert the user to install DISPATCHES through the optional installation. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

