### PR TITLE
Initial Storage as Percentage

### DIFF
--- a/tests/integration_tests/mechanics/pyomo_options/heron_input.xml
+++ b/tests/integration_tests/mechanics/pyomo_options/heron_input.xml
@@ -54,7 +54,7 @@
           <fixed_value>100</fixed_value>
         </capacity>
         <initial_stored>
-          <fixed_value>1</fixed_value>
+          <fixed_value>0.01</fixed_value>
         </initial_stored>
       </stores>
       <economics>

--- a/tests/integration_tests/mechanics/storage_func/heron_input.xml
+++ b/tests/integration_tests/mechanics/storage_func/heron_input.xml
@@ -49,7 +49,7 @@
           <fixed_value>100</fixed_value>
         </capacity>
         <initial_stored>
-          <fixed_value>1</fixed_value>
+          <fixed_value>0.01</fixed_value>
         </initial_stored>
         <strategy>
           <Function method="tiered">storage_control</Function>

--- a/tests/integration_tests/workflows/MOPED/storage_heavy/gold/opt_solution.csv
+++ b/tests/integration_tests/workflows/MOPED/storage_heavy/gold/opt_solution.csv
@@ -1,2 +1,2 @@
 ,npp Capacity,battery Capacity,import Capacity,Expected NPV
-0,25.0,4.9509,100.0,-9864000000.87
+0,25.0,10.8773172448,100.0,-16549511287.5

--- a/tests/integration_tests/workflows/MOPED/storage_heavy/moped_input.xml
+++ b/tests/integration_tests/workflows/MOPED/storage_heavy/moped_input.xml
@@ -74,7 +74,7 @@
           <opt_bounds>1,15</opt_bounds>
         </capacity>
         <initial_stored>
-          <fixed_value>1</fixed_value>
+          <fixed_value>0.5</fixed_value>
         </initial_stored>
         <RTE>0.9</RTE>
       </stores>

--- a/tests/integration_tests/workflows/storage/heron_input.xml
+++ b/tests/integration_tests/workflows/storage/heron_input.xml
@@ -53,7 +53,7 @@
           <fixed_value>100</fixed_value>
         </capacity>
         <initial_stored>
-          <fixed_value>1</fixed_value>
+          <fixed_value>0.01</fixed_value>
         </initial_stored>
         <RTE>0.9</RTE>
       </stores>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #243 

##### What are the significant changes in functionality due to this change request?
Previously HERON did not check that initial stored resources did not exceed the capacity of the storage, which it logically should do.

In addition to addressing this, a _backward incompatible_ change is introduced to change `<initial_stored>` from the amount of resource stored, to a percentage (0, 1) of the storage capacity that is filled, which scales better with optimizing storage size.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

