### PR TITLE
Workbench integration

### DIFF
--- a/src/input_definition.py
+++ b/src/input_definition.py
@@ -44,7 +44,7 @@ def emitDefinition(cls, level=0, occurs=None):
   if occurs is not None:
     # None indicates the default of 0 and NoLimit and not need to be output
     print (indent(level), "MinOccurs=",occurs[0]," MaxOccurs=",occurs[1])
-  if cls.subs:      
+  if cls.subs:
       if cls.subOrder is not None:
         subList = cls.subOrder
       else:
@@ -61,17 +61,17 @@ def emitDefinition(cls, level=0, occurs=None):
           elif quantity == Quantity.one_to_infinity:
             subOccurs = ('1','NoLimit')
           else:
-            print("ERROR unexpected quantity ",quantity)          
+            print("ERROR unexpected quantity ",quantity)
         emitDefinition(sub, level+1, subOccurs)
   else:
-    
+
     if hasattr(cls, 'enumList') and cls.enumList is not None:
         print(indent(level+2),"value{MinOccurs=1 MaxOccurs=1")
         emitValEnumDefinition(cls, level+3)
         print(indent(level+2),"}")
     if cls.contentType is not None:
       xmltype = cls.contentType.getXMLType()
-      # complex types (those not a part of xsd) are captured by 
+      # complex types (those not a part of xsd) are captured by
       # other constraints. We don't output string as this is the default
       isXSD = xmltype.startswith("xsd:")
 
@@ -79,7 +79,7 @@ def emitDefinition(cls, level=0, occurs=None):
       if isXSD and xmltype != "xsd:string":
         print (indent(level+3), "ValType=", {"double":"Real", "integer":"Int"}[xmltype[4:]])
 
-      if not isXSD:        
+      if not isXSD:
         emitValEnumDefinition(cls.contentType, level+3)
       print (indent(level+3),"MinOccurs=0 MaxOccurs=NoLimit")
       print(indent(level+2),"}")
@@ -124,7 +124,7 @@ def print_input_definition():
   """
   print ("%-START-SON-DEFINITION-%")
   print ("% SON-DEFINITION is defined by rules documented at https://code.ornl.gov/neams-workbench/wasp/-/blob/master/wasphive/README.md")
-  
+
   emitDefinition(Cases.Case("~").get_input_specs(), level=0, occurs=None)
   print ("Components{ MinOccurs=1 InputTmpl=element")
   emitDefinition(Components.Component(loc="~").get_input_specs(), level=0, occurs=None)

--- a/src/input_definition.py
+++ b/src/input_definition.py
@@ -1,0 +1,136 @@
+#
+# Copyright 2022, Battelle Energy Alliance, LLC
+# ALL RIGHTS RESERVED
+"""
+  Load HERON input schematic and emit a WASP-formatted input definition
+  for use with EDDI-formatted input in the NEAMS Workbench
+"""
+import sys
+import xml.etree.ElementTree as ET
+
+from . import Cases
+from . import Components
+from . import Placeholders
+
+from . import _utils as hutils
+try:
+  import ravenframework
+except ModuleNotFoundError:
+  raven_path = hutils.get_raven_loc()
+  sys.path.append(raven_path)
+from ravenframework.utils import xmlUtils
+from ravenframework.utils.InputData import Quantity
+
+def indent(level):
+    """Obtain an indent prefix whitespace string"""
+    return " "*level*2
+
+def emitValEnumDefinition(cls, level):
+    """Emit the value enumeration restriction"""
+    enum = ' '.join(cls.enumList)
+    print (indent(level),"ValEnums[",enum,"]")
+
+def emitDefinition(cls, level=0, occurs=None):
+  """
+    Generates the input definition information for this node.
+  """
+  print (indent(level), cls.getName(), "{")
+  if cls.description:
+    print (indent(level+1),"Description=\""+cls.description.replace("\n"," ").replace("                          ", " ").replace("\"","'")+"\"")
+  templateName = "'element'"
+  if occurs is not None:
+    # None indicates the default of 0 and NoLimit and not need to be output
+    print (indent(level), "MinOccurs=",occurs[0]," MaxOccurs=",occurs[1])
+  if cls.subs:      
+      if cls.subOrder is not None:
+        subList = cls.subOrder
+      else:
+        subList = [(sub, Quantity.zero_to_infinity) for sub in cls.subs]
+      for sub, quantity in subList:
+        subOccurs = None
+        if cls.subOrder is not None:
+          if quantity == Quantity.zero_to_one:
+            occurs = ('0','1')
+          elif quantity == Quantity.zero_to_infinity:
+            subOccurs = None # Default is ('0','NoLimit')
+          elif quantity == Quantity.one:
+            subOccurs = ('1','1')
+          elif quantity == Quantity.one_to_infinity:
+            subOccurs = ('1','NoLimit')
+          else:
+            print("ERROR unexpected quantity ",quantity)          
+        emitDefinition(sub, level+1, subOccurs)
+  else:
+    
+    if hasattr(cls, 'enumList') and cls.enumList is not None:
+        print(indent(level+2),"value{MinOccurs=1 MaxOccurs=1")
+        emitValEnumDefinition(cls, level+3)
+        print(indent(level+2),"}")
+    if cls.contentType is not None:
+      xmltype = cls.contentType.getXMLType()
+      # complex types (those not a part of xsd) are captured by 
+      # other constraints. We don't output string as this is the default
+      isXSD = xmltype.startswith("xsd:")
+      
+      print(indent(level+2),"value{")
+      if isXSD and xmltype != "xsd:string":
+        print (indent(level+3), "ValType=", {"double":"Real", "integer":"Int"}[xmltype[4:]])
+        
+      if not isXSD:        
+        emitValEnumDefinition(cls.contentType, level+3)
+      print (indent(level+3),"MinOccurs=0 MaxOccurs=NoLimit")
+      print(indent(level+2),"}")
+  #generate attributes and determine if it has a 'name' attribute
+  hasName = False
+  for parameter in cls.parameters:
+    parameterData = cls.parameters[parameter]
+    print(indent(level+1), parameter, "{")
+    dataType = parameterData["type"]
+    isRequired = parameterData["required"]
+    # alias name to first index of parent element
+    if parameter == "name":
+      hasName = True
+      print(indent(level+2), "InputAliases[\"_0\"]")
+    elif hasattr(dataType, 'enumList'):
+      print(indent(level+2),"value{MinOccurs=1 MaxOccurs=1")
+      emitValEnumDefinition(dataType, level+3)
+      print(indent(level+2),"}")
+    
+    if isRequired:
+      print(indent(level+2), 'MinOccurs=1 MaxOccurs=1')
+    else:
+      # attributes can only occur maximally once
+      print(indent(level+3), "MaxOccurs=1")
+    print (indent(level+2), "InputTmpl='attribute'")
+    print(indent(level+1), "} % end of attribute ", parameter)
+  if cls.subs:
+    
+    # if element has a 'name' attribute we alias name to first value
+    # else no name AND sub elements we must highlight 'value' nodes are UNKNOWN
+    if hasName == False:
+      print (indent(level+1), "InputTmpl='element'")
+      print(indent(level+1),"value(UNKNOWN){}")
+    else:
+      print (indent(level+1), "InputTmpl='named-element'")
+  else:
+    print (indent(level+1), "InputTmpl='leaf-element'")
+  print (indent(level), '} % end of element ', cls.getName())
+
+def print_input_definition():
+  """
+    Obtain object input specifications and print input definition to stdout
+  """
+  print ("%-START-SON-DEFINITION-%")
+  print ("% SON-DEFINITION is defined by rules documented at https://code.ornl.gov/neams-workbench/wasp/-/blob/master/wasphive/README.md")
+  
+  emitDefinition(Cases.Case("~").get_input_specs(), level=0, occurs=None)
+  print ("Components{ MinOccurs=1 InputTmpl=element")
+  emitDefinition(Components.Component(loc="~").get_input_specs(), level=0, occurs=None)
+  print ("}")
+  # deal with DataGenerators
+  print("DataGenerators{ MinOccurs=1 InputTmpl=element")
+  for obj in [Placeholders.CSV(loc="~"),Placeholders.ARMA(loc="~"), Placeholders.Function(loc="~"), Placeholders.ROM(loc="~")]:
+    emitDefinition(obj.get_input_specs(), level=1, occurs=None)
+  print ("}")
+  print ("%-END-SON-DEFINITION-%")
+

--- a/src/input_definition.py
+++ b/src/input_definition.py
@@ -36,7 +36,10 @@ def emitDefinition(cls, level=0, occurs=None):
   """
   print (indent(level), cls.getName(), "{")
   if cls.description:
-    print (indent(level+1),"Description=\""+cls.description.replace("\n"," ").replace("                          ", " ").replace("\"","'")+"\"")
+    print (indent(level+1),"Description=\""+cls.description.replace("\n"," ") \
+                                                           .replace("               ", " ") \
+                                                           .replace("\"","'") \
+                                                           .replace("         ","")+"\"")
   templateName = "'element'"
   if occurs is not None:
     # None indicates the default of 0 and NoLimit and not need to be output
@@ -132,5 +135,7 @@ def print_input_definition():
   for obj in [Placeholders.CSV(loc="~"),Placeholders.ARMA(loc="~"), Placeholders.Function(loc="~"), Placeholders.ROM(loc="~")]:
     emitDefinition(obj.get_input_specs(), level=1, occurs=None)
   print ("}")
+  # Ensure value nodes cannot exist at the root of the document
+  print(indent(0),"value(UNKNOWN){}")
   print ("%-END-SON-DEFINITION-%")
 

--- a/src/input_definition.py
+++ b/src/input_definition.py
@@ -74,11 +74,11 @@ def emitDefinition(cls, level=0, occurs=None):
       # complex types (those not a part of xsd) are captured by 
       # other constraints. We don't output string as this is the default
       isXSD = xmltype.startswith("xsd:")
-      
+
       print(indent(level+2),"value{")
       if isXSD and xmltype != "xsd:string":
         print (indent(level+3), "ValType=", {"double":"Real", "integer":"Int"}[xmltype[4:]])
-        
+
       if not isXSD:        
         emitValEnumDefinition(cls.contentType, level+3)
       print (indent(level+3),"MinOccurs=0 MaxOccurs=NoLimit")
@@ -98,7 +98,7 @@ def emitDefinition(cls, level=0, occurs=None):
       print(indent(level+2),"value{MinOccurs=1 MaxOccurs=1")
       emitValEnumDefinition(dataType, level+3)
       print(indent(level+2),"}")
-    
+
     if isRequired:
       print(indent(level+2), 'MinOccurs=1 MaxOccurs=1')
     else:
@@ -107,7 +107,6 @@ def emitDefinition(cls, level=0, occurs=None):
     print (indent(level+2), "InputTmpl='attribute'")
     print(indent(level+1), "} % end of attribute ", parameter)
   if cls.subs:
-    
     # if element has a 'name' attribute we alias name to first value
     # else no name AND sub elements we must highlight 'value' nodes are UNKNOWN
     if hasName == False:

--- a/src/input_definition.py
+++ b/src/input_definition.py
@@ -24,15 +24,17 @@ from ravenframework.utils.InputData import Quantity
 def indent(level):
     """
       Obtain an indent prefix whitespace string.
-      @ In, int, the number of indentation levels to use.
-      @ Out, indent, the resultant indentation
+      @ In, level, int, the number of indentation levels to use.
+      @ Out, indent, str, the resultant indentation
     """
     return " "*level*2
 
 def emitValEnumDefinition(cls, level):
     """
        Emit the value enumeration restriction
-       @ In, int, the number of indentation levels to use for this component.
+       @ In, cls, ParameterInput class, component definition
+       @ In, level, int, the number of indentation levels to use for this component.
+       @ Out, None
     """
     enum = ' '.join(cls.enumList)
     print (indent(level),"ValEnums[",enum,"]")
@@ -40,8 +42,10 @@ def emitValEnumDefinition(cls, level):
 def emitDefinition(cls, level=0, occurs=None):
   """
     Generates the input definition information for this node.
-    @ In, int, the number of indentation levels to use for this component.
-    @ In, the occurrence restriction for this component
+    @ In, cls, ParameterInput class, component definition
+    @ In, level, int, the number of indentation levels to use for this component.
+    @ In, occurs, tuple(min,max), the occurrence restriction for this component. Max can be 'NoLimit'
+    @ Out, None
   """
   print (indent(level), cls.getName(), "{")
   if cls.description:
@@ -131,7 +135,7 @@ def print_input_definition():
   """
     Obtain object input specifications and print input definition to stdout
     @ In, None
-    @ Out, the SON-formatted input requirements
+    @ Out, None
   """
   print ("%-START-SON-DEFINITION-%")
   print ("% SON-DEFINITION is defined by rules documented at https://code.ornl.gov/neams-workbench/wasp/-/blob/master/wasphive/README.md")

--- a/src/input_definition.py
+++ b/src/input_definition.py
@@ -22,17 +22,26 @@ from ravenframework.utils import xmlUtils
 from ravenframework.utils.InputData import Quantity
 
 def indent(level):
-    """Obtain an indent prefix whitespace string"""
+    """
+      Obtain an indent prefix whitespace string.
+      @ In, int, the number of indentation levels to use.
+      @ Out, indent, the resultant indentation
+    """
     return " "*level*2
 
 def emitValEnumDefinition(cls, level):
-    """Emit the value enumeration restriction"""
+    """
+       Emit the value enumeration restriction
+       @ In, int, the number of indentation levels to use for this component.
+    """
     enum = ' '.join(cls.enumList)
     print (indent(level),"ValEnums[",enum,"]")
 
 def emitDefinition(cls, level=0, occurs=None):
   """
     Generates the input definition information for this node.
+    @ In, int, the number of indentation levels to use for this component.
+    @ In, the occurrence restriction for this component
   """
   print (indent(level), cls.getName(), "{")
   if cls.description:
@@ -121,6 +130,8 @@ def emitDefinition(cls, level=0, occurs=None):
 def print_input_definition():
   """
     Obtain object input specifications and print input definition to stdout
+    @ In, None
+    @ Out, the SON-formatted input requirements
   """
   print ("%-START-SON-DEFINITION-%")
   print ("% SON-DEFINITION is defined by rules documented at https://code.ornl.gov/neams-workbench/wasp/-/blob/master/wasphive/README.md")

--- a/src/input_definition.py
+++ b/src/input_definition.py
@@ -37,7 +37,7 @@ def emitValEnumDefinition(cls, level):
        @ Out, None
     """
     enum = ' '.join(cls.enumList)
-    print (indent(level),"ValEnums[",enum,"]")
+    print(indent(level),"ValEnums[",enum,"]")
 
 def emitDefinition(cls, level=0, occurs=None):
   """
@@ -47,16 +47,16 @@ def emitDefinition(cls, level=0, occurs=None):
     @ In, occurs, tuple(min,max), the occurrence restriction for this component. Max can be 'NoLimit'
     @ Out, None
   """
-  print (indent(level), cls.getName(), "{")
+  print(indent(level), cls.getName(), "{")
   if cls.description:
-    print (indent(level+1),"Description=\""+cls.description.replace("\n"," ") \
+    print(indent(level+1),"Description=\""+cls.description.replace("\n"," ") \
                                                            .replace("               ", " ") \
                                                            .replace("\"","'") \
                                                            .replace("         ","")+"\"")
   templateName = "'element'"
   if occurs is not None:
     # None indicates the default of 0 and NoLimit and not need to be output
-    print (indent(level), "MinOccurs=",occurs[0]," MaxOccurs=",occurs[1])
+    print(indent(level), "MinOccurs=",occurs[0]," MaxOccurs=",occurs[1])
   if cls.subs:
       if cls.subOrder is not None:
         subList = cls.subOrder
@@ -90,11 +90,11 @@ def emitDefinition(cls, level=0, occurs=None):
 
       print(indent(level+2),"value{")
       if isXSD and xmltype != "xsd:string":
-        print (indent(level+3), "ValType=", {"double":"Real", "integer":"Int"}[xmltype[4:]])
+        print(indent(level+3), "ValType=", {"double":"Real", "integer":"Int"}[xmltype[4:]])
 
       if not isXSD:
         emitValEnumDefinition(cls.contentType, level+3)
-      print (indent(level+3),"MinOccurs=0 MaxOccurs=NoLimit")
+      print(indent(level+3),"MinOccurs=0 MaxOccurs=NoLimit")
       print(indent(level+2),"}")
   #generate attributes and determine if it has a 'name' attribute
   hasName = False
@@ -117,19 +117,19 @@ def emitDefinition(cls, level=0, occurs=None):
     else:
       # attributes can only occur maximally once
       print(indent(level+3), "MaxOccurs=1")
-    print (indent(level+2), "InputTmpl='attribute'")
+    print(indent(level+2), "InputTmpl='attribute'")
     print(indent(level+1), "} % end of attribute ", parameter)
   if cls.subs:
     # if element has a 'name' attribute we alias name to first value
     # else no name AND sub elements we must highlight 'value' nodes are UNKNOWN
     if hasName == False:
-      print (indent(level+1), "InputTmpl='element'")
+      print(indent(level+1), "InputTmpl='element'")
       print(indent(level+1),"value(UNKNOWN){}")
     else:
-      print (indent(level+1), "InputTmpl='named-element'")
+      print(indent(level+1), "InputTmpl='named-element'")
   else:
-    print (indent(level+1), "InputTmpl='leaf-element'")
-  print (indent(level), '} % end of element ', cls.getName())
+    print(indent(level+1), "InputTmpl='leaf-element'")
+  print(indent(level), '} % end of element ', cls.getName())
 
 def print_input_definition():
   """
@@ -137,19 +137,19 @@ def print_input_definition():
     @ In, None
     @ Out, None
   """
-  print ("%-START-SON-DEFINITION-%")
-  print ("% SON-DEFINITION is defined by rules documented at https://code.ornl.gov/neams-workbench/wasp/-/blob/master/wasphive/README.md")
+  print("%-START-SON-DEFINITION-%")
+  print("% SON-DEFINITION is defined by rules documented at https://code.ornl.gov/neams-workbench/wasp/-/blob/master/wasphive/README.md")
 
   emitDefinition(Cases.Case("~").get_input_specs(), level=0, occurs=None)
-  print ("Components{ MinOccurs=1 InputTmpl=element")
+  print("Components{ MinOccurs=1 InputTmpl=element")
   emitDefinition(Components.Component(loc="~").get_input_specs(), level=0, occurs=None)
-  print ("}")
+  print("}")
   # deal with DataGenerators
   print("DataGenerators{ MinOccurs=1 InputTmpl=element")
   for obj in [Placeholders.CSV(loc="~"),Placeholders.ARMA(loc="~"), Placeholders.Function(loc="~"), Placeholders.ROM(loc="~")]:
     emitDefinition(obj.get_input_specs(), level=1, occurs=None)
-  print ("}")
+  print("}")
   # Ensure value nodes cannot exist at the root of the document
   print(indent(0),"value(UNKNOWN){}")
-  print ("%-END-SON-DEFINITION-%")
+  print("%-END-SON-DEFINITION-%")
 

--- a/src/main.py
+++ b/src/main.py
@@ -162,9 +162,20 @@ def main():
     @ Out, None
   """
   parser = argparse.ArgumentParser(description='Holistic Energy Resource Optimization Network (HERON)')
-  parser.add_argument('xml_input_file', help='HERON XML input file')
+  parser.add_argument('xml_input_file', nargs='?', default="", help='HERON XML input file')
+  parser.add_argument('--definition', action="store_true", dest="definition", help='HERON input file definition compatible with the NEAMS Workbench')
   args = parser.parse_args()
+  
   sim = HERON()
+  
+  # User requested the input definition be printed
+  if args.definition:
+    from HERON.src import input_definition
+    input_definition.print_input_definition()
+    sys.exit(0)
+  if args.xml_input_file == "":
+    parser.error("the following arguments are required: xml_input_file")
+
   sim.read_input(args.xml_input_file) # TODO expand to use arguments?
   # print details
   sim.print_me()

--- a/src/main.py
+++ b/src/main.py
@@ -165,9 +165,9 @@ def main():
   parser.add_argument('xml_input_file', nargs='?', default="", help='HERON XML input file')
   parser.add_argument('--definition', action="store_true", dest="definition", help='HERON input file definition compatible with the NEAMS Workbench')
   args = parser.parse_args()
-  
+
   sim = HERON()
-  
+
   # User requested the input definition be printed
   if args.definition:
     from HERON.src import input_definition
@@ -187,7 +187,6 @@ def main():
     sim.run_moped_workflow()
   elif sim._case._workflow == 'DISPATCHES':
     sim.run_dispatches_workflow()
-
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
This addresses #259

##### What are the significant changes in functionality due to this change request?
A new command line option `--definition` emits the HERON input schema in a format compatible with the NEAMS Workbench.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

