### PR TITLE
Pyomo solver tolerances

### DIFF
--- a/tests/integration_tests/mechanics/pyomo_options/heron_input.xml
+++ b/tests/integration_tests/mechanics/pyomo_options/heron_input.xml
@@ -32,6 +32,7 @@
         <rolling_window_length>8</rolling_window_length>
         <debug_mode>True</debug_mode>
         <solver>cbc</solver>
+        <tol>1e-3</tol>
       </pyomo>
     </dispatcher>
   </Case>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #67 

##### What are the significant changes in functionality due to this change request?
Adds convergence tolerance options for glpk, cbc, and ipopt when using pyomo dispatcher.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

