### PR TITLE
Need to find a better way to specify "farm_loc"

### DIFF
--- a/src/validators/Factory.py
+++ b/src/validators/Factory.py
@@ -8,23 +8,23 @@ import sys
 # set up path of raven
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import _utils as hutils
+# try:
+#   import FARM.src
+#   farm_loc = FARM.__path__
+# except ModuleNotFoundError:
 try:
-  import FARM.src
-  farm_loc = FARM.__path__
+  raven_path = hutils.get_raven_loc()
+
+  # set up path of farm
+  farm_loc = hutils.get_farm_loc(raven_path=raven_path)
+
+  if farm_loc is not None:
+    farm_path = os.path.abspath(os.path.join(farm_loc))
+    sys.path.append(farm_path)
 except ModuleNotFoundError:
-  try:
-    raven_path = hutils.get_raven_loc()
-
-    # set up path of farm
-    farm_loc = hutils.get_farm_loc(raven_path=raven_path)
-
-    if farm_loc is not None:
-      farm_path = os.path.abspath(os.path.join(farm_loc))
-      sys.path.append(farm_path)
-  except ModuleNotFoundError:
-    farm_loc = None
-  except OSError:
-    farm_loc = None
+  farm_loc = None
+except OSError:
+  farm_loc = None
 
 if farm_loc is not None:
   from FARM.src.FARMValidatorsForHeron import FARM_SISO, FARM_MIMO


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
This is not urgent, it can wait after the https://github.com/idaholab/raven/pull/2235 gets merged.

Without installing FARM plugin through `raven/scripts/install_plugins.py -s FARM`, HERON might occasionally pick up FARM (maybe from previous installation, or existing entries in `sys.path`?) via the line `import FARM.src` in `HERON/src/validators/Factory.py`.
A tentative solution is proposed in this PR, but it may not be the best solution:

- This tentative solution finds the `farm_loc` using `hutils.get_farm_loc`, and then append it to the `sys.path`;
- If the `sys.path` contains another entry of "FARM", will it cause any confusion?


##### What are the significant changes in functionality due to this change request?

- I commented out the lines `import FARM.src` and `farm_loc = FARM.__path__`, 
- I suggest to directly use the `farm_loc = hutils.get_farm_loc(raven_path=raven_path)` to specify the location of FARM.

It would be perfect if we can force the code to search the `farm_loc` only, and import `FARM_SISO` and `FARM_MIMO` from that folder. However, I am unsure how to do this properly... 

Any advices are appreciated!

Thanks,
Haoyu


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

