### PR TITLE
Try to fix failing windows tests

### DIFF
--- a/src/dispatch/pyomo_dispatch.py
+++ b/src/dispatch/pyomo_dispatch.py
@@ -310,6 +310,7 @@ class Pyomo(Dispatcher):
 
     while not done_and_checked:
       attempts += 1
+      print(f'DEBUGG using solver: {self._solver}')
       print(f'DEBUGG solve attempt {attempts} ...:')
       soln = pyo.SolverFactory(self._solver).solve(m.model, options=self.solve_options)
 

--- a/tests/integration_tests/mechanics/pyomo_options/tests
+++ b/tests/integration_tests/mechanics/pyomo_options/tests
@@ -2,7 +2,7 @@
   [./PyomoOptions]
     type = HeronIntegration
     input = heron_input.xml
-    needed_executable = 'ipopt'
+    needed_executable = 'cbc'
     # prereq = SineArma
     [./csv]
       type = OrderedCSV

--- a/tests/integration_tests/workflows/storage/heron_input.xml
+++ b/tests/integration_tests/workflows/storage/heron_input.xml
@@ -26,7 +26,10 @@
       <verbosity>50</verbosity>
     </economics>
     <dispatcher>
-      <pyomo><debug_mode>True</debug_mode></pyomo>
+      <pyomo>
+        <debug_mode>True</debug_mode>
+        <solver>cbc</solver>
+      </pyomo>
     </dispatcher>
     <dispatch_vars>
       <variable name='NPP_bid_adjust'>

--- a/tests/integration_tests/workflows/storage/tests
+++ b/tests/integration_tests/workflows/storage/tests
@@ -2,7 +2,7 @@
   [./Storage]
     type = HeronIntegration
     input = heron_input.xml
-    needed_executable = 'ipopt'
+    needed_executable = 'cbc'
     # prereq = SineArma
     [./csv]
       type = OrderedCSV


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?

#74

##### What are the significant changes in functionality due to this change request?

This pins two tests to using `cbc` as a solver. There was previously a descrepancy with the `needed_executable` specified in the `test` file and the solver actually used in the test. This PR just ensures that the tests files and the input file match up. 

**Will most likely result in the `PyomoOptions` and `Storage` test to be skipped on our Windows test machine**


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

