### PR TITLE
Function custom XML nodes

### DIFF
--- a/src/ValuedParams/Activity.py
+++ b/src/ValuedParams/Activity.py
@@ -86,12 +86,13 @@ class Activity(ValuedParam):
       'was not found among this Component\'s input/output resources; options are:' +
       f'{", ".join(str_avail)}')
 
-  def evaluate(self, inputs, target_var=None, aliases=None):
+  def evaluate(self, inputs, target_var=None, aliases=None, custom_input=None):
     """
       Evaluate this ValuedParam, wherever it gets its data from
       @ In, inputs, dict, stuff from RAVEN, particularly including the keys 'meta' and 'raven_vars'
       @ In, target_var, str, optional, requested outgoing variable name if not None
       @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ In, custom_input, list, optional, additional input nodes from user input
       @ Out, value, dict, dictionary of resulting evaluation as {vars: vals}
       @ Out, meta, dict, dictionary of meta (possibly changed during evaluation)
     """

--- a/src/ValuedParams/Factory.py
+++ b/src/ValuedParams/Factory.py
@@ -51,7 +51,7 @@ class ValuedParamFactory(EntityFactory):
     for typ, klass in self._registeredTypes.items():
       if typ in allowed:
         spec.addSub(klass.get_input_specs())
-        # addons
+    # addons
     spec.addSub(
       InputData.parameterInputFactory(
         'multiplier',
@@ -59,6 +59,12 @@ class ValuedParamFactory(EntityFactory):
         descr=r"""Multiplies any value obtained by this parameter by the given value. \default{1}"""
       )
     )
+    addl_spec = InputData.parameterInputFactory(
+      'AdditionalInfo',
+      descr=r"""Additional arbitrary input information. TODO more info."""
+    )
+    addl_spec.setStrictMode(False)
+    spec.addSub(addl_spec)
     return spec
 
 factory = ValuedParamFactory('ValuedParam')

--- a/src/ValuedParams/Factory.py
+++ b/src/ValuedParams/Factory.py
@@ -61,7 +61,12 @@ class ValuedParamFactory(EntityFactory):
     )
     addl_spec = InputData.parameterInputFactory(
       'AdditionalInfo',
-      descr=r"""Additional arbitrary input information. TODO more info."""
+      descr=r"""Additional arbitrary input information. For custom-defined parameters, such as \xmlNode{Function},
+            the additional information will be passed as part of the `texttt{meta[``HERON''][``custom_input'']}
+            passed to the user-supplied custom evaluation definition.
+            In the case of the \xmlNode{Function}, this is passed to the method in the Python module indicated by
+            the user, and will be unique for each use of the \xmlNode{Function} in the HERON input. Note that
+            the custom input nodes are not checked in any way by the input parsing."""
     )
     addl_spec.setStrictMode(False)
     spec.addSub(addl_spec)

--- a/src/ValuedParams/Function.py
+++ b/src/ValuedParams/Function.py
@@ -24,7 +24,6 @@ class Function(ValuedParam):
         in the \xmlNode{DataGenerators} node.""")
     spec.addParam('method', param_type=InputTypes.StringType,
         descr=r"""the name of the \xmlNode{DataGenerator} from which this value should be taken.""")
-    # TODO add generic spec that is read in as-is
     return spec
 
   def __init__(self):
@@ -54,17 +53,20 @@ class Function(ValuedParam):
     self._method_name = spec.parameterValues['method']
     return [self._method_name]
 
-  def evaluate(self, inputs, target_var=None, aliases=None):
+  def evaluate(self, inputs, target_var=None, aliases=None, custom_input=None):
     """
       Evaluate this ValuedParam, wherever it gets its data from
       @ In, inputs, dict, stuff from RAVEN, particularly including the keys 'meta' and 'raven_vars'
       @ In, target_var, str, optional, requested outgoing variable name if not None
       @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ In, custom_input, list, optional, additional input nodes from user input
       @ Out, data, dict, dictionary of resulting evaluation as {vars: vals}
       @ Out, meta, dict, dictionary of meta (possibly changed during evaluation)
     """
     if aliases is None:
       aliases = {}
+    if custom_input is not None:
+      inputs['HERON']['custom_input'] = custom_input
     # TODO how to handle aliases for functions?
     # the "request" is what we're asking for from the function, the first argument given.
     # -> note it can be None if the function is not a transfer-type function

--- a/src/ValuedParams/Function.py
+++ b/src/ValuedParams/Function.py
@@ -24,6 +24,7 @@ class Function(ValuedParam):
         in the \xmlNode{DataGenerators} node.""")
     spec.addParam('method', param_type=InputTypes.StringType,
         descr=r"""the name of the \xmlNode{DataGenerator} from which this value should be taken.""")
+    # TODO add generic spec that is read in as-is
     return spec
 
   def __init__(self):

--- a/src/ValuedParams/Parametric.py
+++ b/src/ValuedParams/Parametric.py
@@ -76,12 +76,13 @@ class Parametric(ValuedParam):
     """
     self._parametric = value
 
-  def evaluate(self, inputs, target_var=None, aliases=None):
+  def evaluate(self, inputs, target_var=None, aliases=None, custom_input=None):
     """
       Evaluate this ValuedParam, wherever it gets its data from
       @ In, inputs, dict, stuff from RAVEN, particularly including the keys 'meta' and 'raven_vars'
       @ In, target_var, str, optional, requested outgoing variable name if not None
       @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ In, custom_input, list, optional, additional input nodes from user input
       @ Out, value, dict, dictionary of resulting evaluation as {vars: vals}
       @ Out, meta, dict, dictionary of meta (possibly changed during evaluation)
     """

--- a/src/ValuedParams/ROM.py
+++ b/src/ValuedParams/ROM.py
@@ -98,12 +98,13 @@ class ROM(ValuedParam):
     self._inputs[name] = {'vp': vp, 'signals': [signal]}
     return signal
 
-  def evaluate(self, inputs, target_var=None, aliases=None):
+  def evaluate(self, inputs, target_var=None, aliases=None, custom_input=None):
     """
       Evaluate this ValuedParam, wherever it gets its data from
       @ In, inputs, dict, run information from RAVEN, including meta and other run info
       @ In, target_var, str, optional, requested outgoing variable name if not None
       @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ In, custom_input, list, optional, additional input nodes from user input
       @ Out, value, dict, dictionary of resulting evaluation as {vars: vals}
       @ Out, inputs, dict, possibly-modified dictionary of run information
     """

--- a/src/ValuedParams/RandomVariable.py
+++ b/src/ValuedParams/RandomVariable.py
@@ -80,12 +80,13 @@ class RandomVariable(ValuedParam):
     self._distribution = self.convert_spec_to_xml(sub_distribution)
     return []
 
-  def evaluate(self, inputs, target_var=None, aliases=None):
+  def evaluate(self, inputs, target_var=None, aliases=None, custom_input=None):
     """
       Evaluate this ValuedParam, wherever it gets its data from
       @ In, inputs, dict, stuff from RAVEN, particularly including the keys 'meta' and 'raven_vars'
       @ In, target_var, str, optional, requested outgoing variable name if not None
       @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ In, custom_input, list, optional, additional input nodes from user input
       @ Out, value, dict, dictionary of resulting evaluation as {vars: vals}
       @ Out, meta, dict, dictionary of meta (possibly changed during evaluation)
     """

--- a/src/ValuedParams/StaticHistory.py
+++ b/src/ValuedParams/StaticHistory.py
@@ -61,12 +61,13 @@ class StaticHistory(ValuedParam):
     self._var_name = spec.parameterValues['variable']
     return [self._var_name]
 
-  def evaluate(self, inputs, target_var=None, aliases=None):
+  def evaluate(self, inputs, target_var=None, aliases=None, custom_input=None):
     """
       Evaluate this ValuedParam, wherever it gets its data from
       @ In, inputs, dict, stuff from RAVEN, particularly including the keys 'meta' and 'raven_vars'
       @ In, target_var, str, optional, requested outgoing variable name if not None
       @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ In, custom_input, list, optional, additional input nodes from user input
       @ Out, value, dict, dictionary of resulting evaluation as {vars: vals}
       @ Out, meta, dict, dictionary of meta (possibly changed during evaluation)
     """

--- a/src/ValuedParams/SyntheticHistory.py
+++ b/src/ValuedParams/SyntheticHistory.py
@@ -59,12 +59,13 @@ class SyntheticHistory(ValuedParam):
     self._var_name = spec.parameterValues['variable']
     return [self._var_name]
 
-  def evaluate(self, inputs, target_var=None, aliases=None):
+  def evaluate(self, inputs, target_var=None, aliases=None, custom_input=None):
     """
       Evaluate this ValuedParam, wherever it gets its data from
       @ In, inputs, dict, stuff from RAVEN, particularly including the keys 'meta' and 'raven_vars'
       @ In, target_var, str, optional, requested outgoing variable name if not None
       @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ In, custom_input, list, optional, additional input nodes from user input
       @ Out, value, dict, dictionary of resulting evaluation as {vars: vals}
       @ Out, meta, dict, dictionary of meta (possibly changed during evaluation)
     """

--- a/src/ValuedParams/ValuedParam.py
+++ b/src/ValuedParams/ValuedParam.py
@@ -106,12 +106,13 @@ class ValuedParam(MessageUser):
     """
     self._target_obj = obj
 
-  def evaluate(self, inputs, target_var=None, aliases=None):
+  def evaluate(self, inputs, target_var=None, aliases=None, custom_input=None):
     """
       Evaluate this ValuedParam, wherever it gets its data from
       @ In, inputs, dict, stuff from RAVEN, particularly including the keys 'meta' and 'raven_vars'
       @ In, target_var, str, optional, requested outgoing variable name if not None
       @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ In, custom_input, list, optional, additional custom inputs
       @ Out, value, dict, dictionary of resulting evaluation as {vars: vals}
       @ Out, meta, dict, dictionary of meta (possibly changed during evaluation)
     """

--- a/src/ValuedParams/Variable.py
+++ b/src/ValuedParams/Variable.py
@@ -45,12 +45,13 @@ class Variable(ValuedParam):
     self._raven_var = spec.value
     return [self._raven_var]
 
-  def evaluate(self, inputs, target_var=None, aliases=None):
+  def evaluate(self, inputs, target_var=None, aliases=None, custom_input=None):
     """
       Evaluate this ValuedParam, wherever it gets its data from
       @ In, inputs, dict, stuff from RAVEN, particularly including the keys 'meta' and 'raven_vars'
       @ In, target_var, str, optional, requested outgoing variable name if not None
       @ In, aliases, dict, optional, alternate variable names for searching in variables
+      @ In, custom_input, list, optional, additional input nodes from user input
       @ Out, value, dict, dictionary of resulting evaluation as {vars: vals}
       @ Out, meta, dict, dictionary of meta (possibly changed during evaluation)
     """

--- a/tests/integration_tests/mechanics/storage_func/heron_input.xml
+++ b/tests/integration_tests/mechanics/storage_func/heron_input.xml
@@ -113,6 +113,14 @@
           </driver>
           <reference_price>
             <Function method="flex_price">transfers</Function>
+            <AdditionalInfo>
+              <General>
+                <TheAnswer>42</TheAnswer>
+                <TheQuestion>unknown</TheQuestion>
+              </General>
+              <scalar>-2</scalar>
+              <loc>-0.5</loc>
+            </AdditionalInfo>
           </reference_price>
         </CashFlow>
       </economics>

--- a/tests/integration_tests/mechanics/storage_func/transfers.py
+++ b/tests/integration_tests/mechanics/storage_func/transfers.py
@@ -16,8 +16,18 @@ def flex_price(data, meta):
   """
   sine = meta['HERON']['RAVEN_vars']['Signal']
   t = meta['HERON']['time_index']
+  # check for the existince of the custom functions
+  for node in meta['HERON']['custom_input']:
+    if node.tag == 'General':
+      ans = node.find('TheAnswer').text
+      qus = node.find('TheQuestion').text
+    elif node.tag == 'scalar':
+      scalar = float(node.text)
+    elif node.tag == 'loc':
+      loc = float(node.text)
+  print(f'The answer to the question "{qus}" is "{ans}".')
   # DispatchManager
   # scale electricity consumed to flex between -1 and 1
-  amount = - 2 * (sine[t] - 0.5)
+  amount = scalar * (sine[t] + loc)
   data = {'reference_price': amount}
   return data, meta


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #340

##### What are the significant changes in functionality due to this change request?
Uses RAVEN's new input spec feature (https://github.com/idaholab/raven/pull/2332) to implement arbitrary function additional XML, which will be passed to the function as part of the `meta` object.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

