### PR TITLE
Update workflow version numbers

### DIFF
--- a/.github/workflows/doc-action.yml
+++ b/.github/workflows/doc-action.yml
@@ -8,7 +8,7 @@ jobs:
    runs-on: [self-hosted, linux]
    steps:
      - name: Checkout repository
-       uses: actions/checkout@v3
+       uses: actions/checkout@v4
      - run: cd .. && rm -Rf raven && git clone https://github.com/idaholab/raven.git
      - run: python3 ../raven/scripts/install_plugins.py -s TEAL
      - run: python3 ../raven/scripts/install_plugins.py -s ${{ github.workspace }}
@@ -21,7 +21,7 @@ jobs:
         cd ../HERON
         ./doc/make_docs.sh
      - name: Archive documents
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: pdfs
          path: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - run: pwd
-      - run: cd .. && rm -Rf raven && git clone https://github.com/idaholab/raven.git
+      - run: cd .. && rm -Rf raven && git clone https://github.com/joshua-coglaiti-inl/raven.git
       - run: python3 ../raven/scripts/install_plugins.py -s TEAL
       - run: python3 ../raven/scripts/install_plugins.py -s ${{ github.workspace }}
       - run: WD=`(cd ../../.. && pwd)` && export RAVEN_LIBS_NAME="raven_libs_"`basename $WD` && ../raven/scripts/establish_conda_env.sh --install

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -9,7 +9,7 @@ jobs:
       - run: echo " This job is now running on a ${{ runner.os }} server"
       - run: echo " The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: pwd
       - run: cd .. && rm -Rf raven && git clone https://github.com/idaholab/raven.git
       - run: python3 ../raven/scripts/install_plugins.py -s TEAL
@@ -25,7 +25,7 @@ jobs:
       - run: echo " This job is now running on a ${{ runner.os }} server"
       - run: echo " The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: pwd
       - run: cd ..; if (Test-Path raven) {Remove-Item -Recurse -Force raven}; git clone https://github.com/idaholab/raven.git
       - run: python ../raven/scripts/install_plugins.py -s TEAL


### PR DESCRIPTION
So I noticed GitHub is deprecating actions/artifact@v3 later this year and moving to actions/artifact@v4. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/. 

I've bumped version numbers for checkout and artifacts actions accordingly. I'd just like to test them at this stage, not planning to merge this PR. Can we kick off a workflow and confirm if these work?