### PR TITLE
Code coverage

### DIFF
--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -55,22 +55,19 @@ DISPLAY_VAR=`(echo $DISPLAY)`
 # reset it
 export DISPLAY=
 
+export COVERAGE_RCFILE="$SRC_DIR/../tests/.coveragerc"
 SOURCE_DIRS=($SRC_DIR,$SRC_DIR/../templates/)
 OMIT_FILES=($SRC_DIR/dispatch/twin_pyomo_test.py,$SRC_DIR/dispatch/twin_pyomo_test_rte.py,$SRC_DIR/dispatch/twin_pyomo_limited_ramp.py)
-EXTRA="--rcfile=$SRC_DIR/../tests/.coveragerc --source=${SOURCE_DIRS[@]} --omit=${OMIT_FILES[@]} --parallel-mode "
+EXTRA="--source=${SOURCE_DIRS[@]} --omit=${OMIT_FILES[@]} --parallel-mode "
 export COVERAGE_FILE=`pwd`/.coverage
 
-coverage erase --rcfile="$SRC_DIR/../tests/.coveragerc"
-($SRC_DIR/../../../run_tests "$@" --re=HERON --python-command="coverage run $EXTRA " || echo run_test done but some tests failed)
+coverage erase
+($SRC_DIR/../../../run_tests "$@" --re=HERON --python-command="coverage run $EXTRA " || echo run_tests done but some tests failed)
 
 #get DISPLAY BACK
 DISPLAY=$DISPLAY_VAR
 
-## Go to the final directory and generate the html documents
-cd $SCRIPT_DIR/tests/
-pwd
-rm -f .cov_dirs
-for FILE in `find . -name '.coverage.*'`; do dirname $FILE; done | sort | uniq > .cov_dirs
-coverage combine `cat .cov_dirs`
+## Prepare data and generate the html documents
+coverage combine
 coverage html
 

--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -57,12 +57,12 @@ export DISPLAY=
 
 export COVERAGE_RCFILE="$SRC_DIR/../tests/.coveragerc"
 SOURCE_DIRS=($SRC_DIR,$SRC_DIR/../templates/)
-OMIT_FILES=($SRC_DIR/dispatch/twin_pyomo_test.py,$SRC_DIR/dispatch/twin_pyomo_test_rte.py,$SRC_DIR/dispatch/twin_pyomo_limited_ramp.py)
+OMIT_FILES=($SRC_DIR/dispatch/twin_pyomo_test.py,$SRC_DIR/dispatch/twin_pyomo_test_rte.py,$SRC_DIR/dispatch/twin_pyomo_limited_ramp.py,$SRC_DIR/ArmaBypass.py)
 EXTRA="--source=${SOURCE_DIRS[@]} --omit=${OMIT_FILES[@]} --parallel-mode "
 export COVERAGE_FILE=`pwd`/.coverage
 
 coverage erase
-($SRC_DIR/../../../run_tests "$@" --re=HERON --python-command="coverage run $EXTRA " || echo run_tests done but some tests failed)
+($SRC_DIR/../../../run_tests "$@" --re=HERON/tests --python-command="coverage run $EXTRA " || echo run_tests done but some tests failed)
 
 #get DISPLAY BACK
 DISPLAY=$DISPLAY_VAR

--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+SCRIPT_DIRNAME=`dirname $0`
+SCRIPT_DIR=`(cd $SCRIPT_DIRNAME; pwd)`
+source $SCRIPT_DIR/../../scripts/establish_conda_env.sh --quiet --load
+RAVEN_LIBS_PATH=`conda env list | awk -v rln="$RAVEN_LIBS_NAME" '$0 ~ rln {print $NF}'`
+BUILD_DIR=${BUILD_DIR:=$RAVEN_LIBS_PATH/build}
+INSTALL_DIR=${INSTALL_DIR:=$RAVEN_LIBS_PATH}
+PYTHON_CMD=${PYTHON_CMD:=python}
+JOBS=${JOBS:=1}
+mkdir -p $BUILD_DIR
+mkdir -p $INSTALL_DIR
+DOWNLOADER='curl -C - -L -O '
+
+ORIGPYTHONPATH="$PYTHONPATH"
+
+update_python_path ()
+{
+    if ls -d $INSTALL_DIR/lib/python*
+    then
+        export PYTHONPATH=`ls -d $INSTALL_DIR/lib/python*/site-packages/`:"$ORIGPYTHONPATH"
+    fi
+}
+
+update_python_path
+PATH=$INSTALL_DIR/bin:$PATH
+
+if which coverage
+then
+    echo coverage already available, skipping building it.
+else
+    if curl http://www.energy.gov > /dev/null
+    then
+       echo Successfully got data from the internet
+    else
+       echo Could not connect to internet
+    fi
+
+    cd $BUILD_DIR
+    #SHA256=56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1
+    $DOWNLOADER https://files.pythonhosted.org/packages/ef/05/31553dc038667012853d0a248b57987d8d70b2d67ea885605f87bcb1baba/coverage-7.5.4.tar.gz
+    tar -xvzf coverage-7.5.4.tar.gz
+    cd coverage-7.5.4
+    (unset CC CXX; $PYTHON_CMD setup.py install --prefix=$INSTALL_DIR)
+fi
+
+update_python_path
+
+cd $SCRIPT_DIR
+
+#coverage help run
+SRC_DIR=`(cd src && pwd)`
+
+# get display var
+DISPLAY_VAR=`(echo $DISPLAY)`
+# reset it
+export DISPLAY=
+
+SOURCE_DIRS=($SRC_DIR,$SRC_DIR/../templates/)
+OMIT_FILES=($SRC_DIR/dispatch/twin_pyomo_test.py,$SRC_DIR/dispatch/twin_pyomo_test_rte.py,$SRC_DIR/dispatch/twin_pyomo_limited_ramp.py)
+EXTRA="--rcfile=$SRC_DIR/../tests/.coveragerc --source=${SOURCE_DIRS[@]} --omit=${OMIT_FILES[@]} --parallel-mode "
+export COVERAGE_FILE=`pwd`/.coverage
+
+coverage erase --rcfile="$SRC_DIR/../tests/.coveragerc"
+($SRC_DIR/../../../run_tests "$@" --re=HERON --python-command="coverage run $EXTRA " || echo run_test done but some tests failed)
+
+#get DISPLAY BACK
+DISPLAY=$DISPLAY_VAR
+
+## Go to the final directory and generate the html documents
+cd $SCRIPT_DIR/tests/
+pwd
+rm -f .cov_dirs
+for FILE in `find . -name '.coverage.*'`; do dirname $FILE; done | sort | uniq > .cov_dirs
+coverage combine `cat .cov_dirs`
+coverage html
+

--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 SCRIPT_DIRNAME=`dirname $0`
 SCRIPT_DIR=`(cd $SCRIPT_DIRNAME; pwd)`
-source $SCRIPT_DIR/../../scripts/establish_conda_env.sh --quiet --load
+RAVEN_DIR=`python -c 'from src._utils import get_raven_loc; print(get_raven_loc())'`
+source $RAVEN_DIR/scripts/establish_conda_env.sh --quiet --load
 RAVEN_LIBS_PATH=`conda env list | awk -v rln="$RAVEN_LIBS_NAME" '$0 ~ rln {print $NF}'`
 BUILD_DIR=${BUILD_DIR:=$RAVEN_LIBS_PATH/build}
 INSTALL_DIR=${INSTALL_DIR:=$RAVEN_LIBS_PATH}
@@ -62,7 +63,7 @@ EXTRA="--source=${SOURCE_DIRS[@]} --omit=${OMIT_FILES[@]} --parallel-mode "
 export COVERAGE_FILE=`pwd`/.coverage
 
 coverage erase
-($SRC_DIR/../../../run_tests "$@" --re=HERON/tests --python-command="coverage run $EXTRA " || echo run_tests done but some tests failed)
+($RAVEN_DIR/run_tests "$@" --re=HERON/tests --python-command="coverage run $EXTRA " || echo run_tests done but some tests failed)
 
 #get DISPLAY BACK
 DISPLAY=$DISPLAY_VAR

--- a/heron
+++ b/heron
@@ -35,9 +35,13 @@ while test $# -gt 0
 do
   # right now we don't have any keyword arguments for this script, but leave this for now
   case "$1" in
+    --python-command=*)
+      PYTHON_COMMAND="${1#*=}"
+      ;;  
     *)
       # otherwise, pass through arguments to main.py
       ARGS[${#ARGS[@]}]="$1"
+      ;;
   esac
   shift
 done

--- a/heron
+++ b/heron
@@ -33,7 +33,6 @@ source $RAVEN_DIR/scripts/establish_conda_env.sh --quiet
 declare -a ARGS
 while test $# -gt 0
 do
-  # right now we don't have any keyword arguments for this script, but leave this for now
   case "$1" in
     --python-command=*)
       PYTHON_COMMAND="${1#*=}"

--- a/src/Cases.py
+++ b/src/Cases.py
@@ -672,6 +672,8 @@ class Case(Base):
         'sigma': None,                 # user can specify additional result statistics
         'expectedValue': None,
         'median': None}
+    
+    self._python_command_for_raven = None # python command to use for raven executable
 
     # clean up location
     self.run_dir = os.path.abspath(os.path.expanduser(self.run_dir))
@@ -1323,6 +1325,23 @@ class Case(Base):
       @ Out, opt_strategy, str, name of optimization algorithm/strategy
     """
     return self._optimization_strategy
+  
+  def get_py_cmd_for_raven(self):
+    """
+      Accessor
+      @ In, None
+      @ Out, py_cmd_for_raven, str, custom python command for running raven (if set)
+    """
+    return self._python_command_for_raven
+  
+  def set_py_cmd_for_raven(self, py_cmd):
+    """
+      Mutator
+      @ In, py_cmd, str, custom python command for running raven
+      @ Out, None
+    """
+    self._python_command_for_raven = py_cmd
+    return
 
   @property
   def npv_target(self):

--- a/src/Cases.py
+++ b/src/Cases.py
@@ -672,7 +672,7 @@ class Case(Base):
         'sigma': None,                 # user can specify additional result statistics
         'expectedValue': None,
         'median': None}
-    
+
     self._python_command_for_raven = None # python command to use for raven executable
 
     # clean up location
@@ -1325,7 +1325,7 @@ class Case(Base):
       @ Out, opt_strategy, str, name of optimization algorithm/strategy
     """
     return self._optimization_strategy
-  
+
   def get_py_cmd_for_raven(self):
     """
       Accessor
@@ -1333,7 +1333,7 @@ class Case(Base):
       @ Out, py_cmd_for_raven, str, custom python command for running raven (if set)
     """
     return self._python_command_for_raven
-  
+
   def set_py_cmd_for_raven(self, py_cmd):
     """
       Mutator

--- a/src/Testers/HeronIntegrationTester.py
+++ b/src/Testers/HeronIntegrationTester.py
@@ -94,7 +94,8 @@ class HeronIntegration(RavenTester):
     if platform.system() == 'Windows':
       cmd += ' bash.exe '
     python = self._get_python_command()
-    cmd += f' {self.heron_driver} --python-command="{python}" {heron_inp}'
+    # python-command is only for running HERON; python_command_for_raven is for running RAVEN on outer and inner
+    cmd += f' {self.heron_driver} --python-command="{python}" --python_command_for_raven="{python}" {heron_inp}'
     return cmd, heron_inp
 
   def get_raven_command(self, cmd, heron_inp):

--- a/src/Testers/HeronIntegrationTester.py
+++ b/src/Testers/HeronIntegrationTester.py
@@ -93,7 +93,8 @@ class HeronIntegration(RavenTester):
     # Windows is a little different with bash scripts
     if platform.system() == 'Windows':
       cmd += ' bash.exe '
-    cmd += f' {self.heron_driver} {heron_inp}'
+    python = self._get_python_command()
+    cmd += f' {self.heron_driver} --python-command="{python}" {heron_inp}'
     return cmd, heron_inp
 
   def get_raven_command(self, cmd, heron_inp):

--- a/src/Testers/HeronIntegrationTester.py
+++ b/src/Testers/HeronIntegrationTester.py
@@ -94,7 +94,7 @@ class HeronIntegration(RavenTester):
     if platform.system() == 'Windows':
       cmd += ' bash.exe '
     python = self._get_python_command()
-    # python-command is only for running HERON; python_command_for_raven is for running RAVEN on outer and inner
+    # python-command is for running HERON; python_command_for_raven is for running RAVEN inner
     cmd += f' {self.heron_driver} --python-command="{python}" --python_command_for_raven="{python}" {heron_inp}'
     return cmd, heron_inp
 

--- a/src/main.py
+++ b/src/main.py
@@ -99,16 +99,20 @@ class HERON(Base):
       img_path = os.path.join(self._input_dir, 'network.png')
       graph.save(img_path)
 
-  def create_raven_workflow(self, case=None):
+  def create_raven_workflow(self, case=None, python_cmd_raven=None):
     """
       Loads, modifies, and writes a RAVEN template workflow based on the Case.
       @ In, case, Cases.Case, optional, case to run (defaults to self._case)
+      @ In, python_cmd_raven, string, optional, custom python command to use for running RAVEN
+          Driving use case is specifying that RAVEN be run with code coverage
       @ Out, None
     """
     if case is None:
       case = self._case
     # let the case do the work
     assert case is not None
+    if python_cmd_raven:
+      case.set_py_cmd_for_raven(python_cmd_raven)
     case.write_workflows(self._components, self._sources, self._input_dir)
 
   def run_moped_workflow(self, case=None, components=None, sources=None):
@@ -163,6 +167,7 @@ def main():
   parser = argparse.ArgumentParser(description='Holistic Energy Resource Optimization Network (HERON)')
   parser.add_argument('xml_input_file', nargs='?', default="", help='HERON XML input file')
   parser.add_argument('--definition', action="store_true", dest="definition", help='HERON input file definition compatible with the NEAMS Workbench')
+  parser.add_argument('--python_command_for_raven', dest='python_cmd_raven', help='Custom python command for running RAVEN on outer and inner')
   args = parser.parse_args()
 
   sim = HERON()
@@ -181,7 +186,10 @@ def main():
   sim.plot_resource_graph()
 
   if sim._case._workflow == 'standard':
-    sim.create_raven_workflow()
+    if args.python_cmd_raven is not None:
+      sim.create_raven_workflow(python_cmd_raven=args.python_cmd_raven)
+    else:
+      sim.create_raven_workflow()
   elif sim._case._workflow == 'MOPED':
     sim.run_moped_workflow()
   elif sim._case._workflow == 'DISPATCHES':

--- a/src/main.py
+++ b/src/main.py
@@ -167,7 +167,7 @@ def main():
   parser = argparse.ArgumentParser(description='Holistic Energy Resource Optimization Network (HERON)')
   parser.add_argument('xml_input_file', nargs='?', default="", help='HERON XML input file')
   parser.add_argument('--definition', action="store_true", dest="definition", help='HERON input file definition compatible with the NEAMS Workbench')
-  parser.add_argument('--python_command_for_raven', dest='python_cmd_raven', help='Custom python command for running RAVEN on outer and inner')
+  parser.add_argument('--python_command_for_raven', dest='python_cmd_raven', help='Custom python command for running RAVEN inner')
   args = parser.parse_args()
 
   sim = HERON()

--- a/templates/template_driver.py
+++ b/templates/template_driver.py
@@ -480,6 +480,11 @@ class Template(TemplateBase, Base):
       raven_exec.text = "raven_framework"
     else:
       raise RuntimeError("raven_framework not in PATH and not at "+raven_exec_guess)
+    # custom python command for running raven (for example, "coverage run")
+    if case.get_py_cmd_for_raven() is not None:
+      attribs = {'type': 'prepend', 'arg': case.get_py_cmd_for_raven()}
+      new = xmlUtils.newNode('clargs', attrib=attribs)
+      raven.append(new)
     # conversion script
     conv = raven.find('conversion').find('input')
     conv.attrib['source'] = '../write_inner.py'

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -29,4 +29,4 @@ exclude_lines =
 ignore_errors = True
 
 [html]
-directory = coverage_html_report
+directory = tests/coverage_html_report

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,0 +1,32 @@
+# .coveragerc to control coverage.py
+[run]
+#branch = True
+parallel = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    #def __repr__
+    #if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    raise IOError
+    raise Exception
+
+    # Don't complain for the things under development
+    pragma: under development
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,7 @@
 The "source" for code coverage defines a list of files over which code coverage is checked. This is defined in the `HERON/check_py_coverage.sh` script. By default when the source directory is specified, coverage.py measures coverage over all files in the source directory(ies) ending with .py, .pyw, .pyo, or .pyc that have typical punctuation. It also measures all files in subdirectories that also include an `__init__.py` file. For details see https://coverage.readthedocs.io/en/7.5.4/source.html#source
 
 HERON code coverage is currently set up to run all files in the `HERON/src/` directory as well as in the `HERON/templates/` directory (provided the limitations listed above). Exceptions, which are in these directories but not covered, are listed as omitted files and directories in `HERON/check_py_coverage.sh`. Currently this list is comprised of the following files:
+- `HERON/src/ARMABypass.py`
 - `HERON/src/dispatch/twin_pyomo_test.py`
 - `HERON/src/dispatch/twin_pyomo_test_rte.py`
 - `HERON/src/dispatch/twin_pyomo_limited_ramp.py`

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+# Code Coverage
+## Coverage source
+The "source" for code coverage defines a list of files over which code coverage is checked. This is defined in the `HERON/check_py_coverage.sh` script. By default when the source directory is specified, coverage.py measures coverage over all files in the source directory(ies) ending with .py, .pyw, .pyo, or .pyc that have typical punctuation. It also measures all files in subdirectories that also include an `__init__.py` file. For details see https://coverage.readthedocs.io/en/7.5.4/source.html#source
+
+HERON code coverage is currently set up to run all files in the `HERON/src/` directory as well as in the `HERON/templates/` directory (provided the limitations listed above). Exceptions, which are in these directories but not covered, are listed as omitted files and directories in `HERON/check_py_coverage.sh`. Currently this list is comprised of the following files:
+- `HERON/src/dispatch/twin_pyomo_test.py`
+- `HERON/src/dispatch/twin_pyomo_test_rte.py`
+- `HERON/src/dispatch/twin_pyomo_limited_ramp.py`
+
+Note additionally that files in some subdirectories of `HERON/src` are omitted automatically by coverage.py because those subdirectories lack an `__init__.py` file. An example is the `HERON/src/Testers/` directory.


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#376

##### What are the significant changes in functionality due to this change request?
This request implements the necessary changes to support functionality of a code coverage script (`HERON/check_py_coverage.sh`). A screenshot of a coverage report produced by this script is attached below. Running the script also prints the location of the complete resulting html report. The script checks the coverage both of HERON functions called before RAVEN outer is run as well as HERON functions called within the run of RAVEN inner (as a side note, these are mostly dispatch-related functions).

**Pre-RAVEN outer coverage tracking**
- A new coverage script has been added that runs `RAVEN/run_tests` with HERON tests only and provides the python command that is eventually passed as an argument to `RAVEN/rook/main.py` (note, rook uses this to set the python command in the testers). The source for coverage measurement is all files in the `HERON/src/` directory and in the `HERON/templates/` directory, as well as those files in any subdirectory of these two that has an `__init__.py` file inside it. Exceptions to this are explicitly listed as `HERON/src/ARMABypass.py` and the three `twin_pyomo` tests in `HERON/src/dispatch/`.
- A configuration file has been added to support the above mentioned coverage script.
- The README.md file in `HERON/tests/` has been updated to document information about code coverage.
- The `HERONIntegration` tester has been modified to pass a command line argument to the `HERON/heron` shell script with a python command for running `HERON/src/main.py`.
- The `HERON/heron` shell script has been modified to use the python command provided in the new optional command line argument if it exists.

**Coverage tracking during RAVEN inner**
- The `HERONIntegration` tester has been modified to pass a second command line argument to the `HERON/heron` shell script providing the python command with which to run `RAVEN/raven_framework.py` on the RAVEN inner input xml script. Both command line arguments (this and the argument mentioned above to specify the python command for running `HERON/src/main.py`) are set to the same string, namely the `python_command` variable in the tester.
- This second command line argument, the python command for running RAVEN inner, is passed unmodified through the `HERON/heron` shell script to `HERON/src/main.py`. The `HERON/src/main.py` script has been modified to recognize this argument and set a variable in `HERON/src/Cases.py` to its value.
- The `HERON/src/Cases.py` script has been modified with an initialization, getter, and setter for the above mentioned variable.
- The `HERON/templates/template_driver.py` has been modified to check whether the case has a specified python command for running RAVEN (the variable in the above bullet). If it exists, a line is added to the `outer.xml` that prepends the python command to the command to run the RAVEN inner.

<img width="737" alt="Screenshot 2024-08-01 at 12 57 46 PM" src="https://github.com/user-attachments/assets/94d96dc7-8565-4b1b-8194-0dd025ed5190">

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

