### PR TITLE
Template Driver fix for Opt mode compatibility with CSV and debug

### DIFF
--- a/templates/template_driver.py
+++ b/templates/template_driver.py
@@ -501,8 +501,8 @@ class Template(TemplateBase, Base):
       text = 'Samplers|CustomSampler@name:mc_arma_dispatch|constant@name:{}'
       # Remove anything having to do with 'denoises', it's no longer needed.
       raven.remove(raven.find(".//alias[@variable='denoises']"))
-      denoises_parent = template.find(".//constant[@name='denoises']/..")
-      denoises_parent.remove(denoises_parent.find(".//constant[@name='denoises']"))
+      for denoises_parent in template.findall(".//constant[@name='denoises']/.."):
+        denoises_parent.remove(denoises_parent.find(".//constant[@name='denoises']"))
       # Remove any GRO_final_return vars that compute Sigma or Var (e.g. var_NPV)
       final_return_vars = template.find('.//VariableGroups/Group[@name="GRO_outer_results"]')
       new_final_return_vars = [var for var in final_return_vars.text.split(", ") if "std" not in var and "var" not in var]

--- a/templates/template_driver.py
+++ b/templates/template_driver.py
@@ -521,7 +521,7 @@ class Template(TemplateBase, Base):
       if cap.is_parametric() and isinstance(cap.get_value(debug=case.debug['enabled']) , list):
         feature_list += name + '_capacity' + ','
     feature_list = feature_list[0:-1]
-    if case.get_mode() == 'opt':
+    if case.get_mode() == 'opt' and (not case.debug['enabled']):
       gpr = template.find('Models').find('ROM')
       gpr.find('Features').text = feature_list
       new_opt_metric = self._build_opt_metric_out_name(case)
@@ -730,8 +730,11 @@ class Template(TemplateBase, Base):
         template.remove(template.find('Samplers'))
         template.find('Models').remove(template.find(".//ROM[@name='gpROM']"))
         template.find('Optimizers').remove(template.find(".//BayesianOptimizer[@name='cap_opt']"))
+    # if running in debug, none of these nodes should be here, skip
+    if case.debug['enabled']:
+      return
     # only modify if optimization_settings is in Case
-    if (case.get_mode() == 'opt') and (case.get_optimization_settings() is not None) and (not case.debug['enabled']):  # TODO there should be a better way to handle the debug case
+    if (case.get_mode() == 'opt') and (case.get_optimization_settings() is not None):  # TODO there should be a better way to handle the debug case
       optimization_settings = case.get_optimization_settings()
       # Strategy tells us which optimizer to use
       if strategy == 'BayesianOpt':

--- a/templates/template_driver.py
+++ b/templates/template_driver.py
@@ -682,7 +682,7 @@ class Template(TemplateBase, Base):
           dist, xml = self._create_new_sweep_capacity(name, var_name, vals, sampler)
           dists_node.append(dist)
           # Bayesian Optimizer requires additional modification
-          if case.get_opt_strategy() == 'BayesianOpt' and case.get_mode() == 'opt':
+          if case.get_opt_strategy() == 'BayesianOpt' and case.get_mode() == 'opt' and (not case.debug['enabled']):
             xml.remove(xml.find('initial'))
             samps_node.append(xml)
             grid_node = xmlUtils.newNode('grid', text='0 1',
@@ -719,7 +719,7 @@ class Template(TemplateBase, Base):
     """
     # Setting base outer for opt based on optimizer used
     strategy = case.get_opt_strategy()
-    if case.get_mode() == 'opt':
+    if case.get_mode() == 'opt'and (not case.debug['enabled']):
       # Strategy tells us which optimizer to use
       if strategy == 'BayesianOpt':
         opt_node = template.find('Optimizers').find(".//BayesianOptimizer[@name='cap_opt']")

--- a/tests/integration_tests/mechanics/debug_mode/opt/heron_input.xml
+++ b/tests/integration_tests/mechanics/debug_mode/opt/heron_input.xml
@@ -11,7 +11,7 @@
   </TestInfo>
 
   <Case name="Debug_Run">
-    <mode>sweep</mode>
+    <mode>opt</mode>
     <debug>
       <inner_samples>2</inner_samples>
       <macro_steps>2</macro_steps>
@@ -39,7 +39,7 @@
     <Component name="steamer">
       <produces resource="steam" dispatch="fixed">
         <capacity resource="steam">
-          <sweep_values debug_value="3.14">1, 100</sweep_values>
+          <opt_bounds debug_value="3.14">1, 100</opt_bounds>
         </capacity>
       </produces>
       <economics>
@@ -107,7 +107,7 @@
 
   <DataGenerators>
     <ARMA name='Price' variable="Signal">%HERON_DATA%/TSA/Sine/arma.pk</ARMA>
-    <Function name="transfers">transfers.py</Function>
+    <Function name="transfers">../transfers.py</Function>
   </DataGenerators>
 
 </HERON>

--- a/tests/integration_tests/mechanics/debug_mode/sweep/heron_input.xml
+++ b/tests/integration_tests/mechanics/debug_mode/sweep/heron_input.xml
@@ -1,0 +1,113 @@
+<HERON>
+  <TestInfo>
+    <name>DebugMode</name>
+    <author>talbpaul</author>
+    <created>2021-02-22</created>
+    <description>
+      Tests a debug mode of operation, where a single outer runs a single sample of inner
+      and outputs the optimized dispatch.
+    </description>
+    <classesTested>HERON</classesTested>
+  </TestInfo>
+
+  <Case name="Debug_Run">
+    <mode>sweep</mode>
+    <debug>
+      <inner_samples>2</inner_samples>
+      <macro_steps>2</macro_steps>
+      <dispatch_plot>True</dispatch_plot>
+    </debug>
+    <num_arma_samples>1</num_arma_samples>
+    <time_discretization>
+      <time_variable>Time</time_variable>
+      <end_time>2</end_time>
+      <num_steps>21</num_steps>
+    </time_discretization>
+    <economics>
+      <ProjectTime>3</ProjectTime>
+      <DiscountRate>0.08</DiscountRate>
+      <tax>0.3</tax>
+      <inflation>0.02</inflation>
+      <verbosity>50</verbosity>
+    </economics>
+    <dispatcher>
+      <pyomo/>
+    </dispatcher>
+  </Case>
+
+  <Components>
+    <Component name="steamer">
+      <produces resource="steam" dispatch="fixed">
+        <capacity resource="steam">
+          <sweep_values debug_value="3.14">1, 100</sweep_values>
+        </capacity>
+      </produces>
+      <economics>
+        <lifetime>5</lifetime>
+      </economics>
+    </Component>
+
+    <Component name="generator">
+      <produces resource="electricity" dispatch="independent">
+        <consumes>steam</consumes>
+        <capacity resource="steam">
+          <fixed_value>-100</fixed_value>
+        </capacity>
+        <transfer>
+          <linear>
+            <rate resource="steam">-1</rate>
+            <rate resource="electricity">0.5</rate>
+          </linear>
+        </transfer>
+      </produces>
+      <economics>
+        <lifetime>5</lifetime>
+      </economics>
+    </Component>
+
+    <Component name="electr_market">
+      <demands resource="electricity" dispatch="dependent">
+        <capacity>
+          <fixed_value>-2</fixed_value>
+        </capacity>
+      </demands>
+      <economics>
+        <lifetime>30</lifetime>
+        <CashFlow name="e_sales" type="repeating" taxable='True' inflation='none' >
+          <driver>
+            <activity>electricity</activity>
+          </driver>
+          <reference_price>
+            <fixed_value>0.5</fixed_value>
+          </reference_price>
+        </CashFlow>
+      </economics>
+    </Component>
+
+    <Component name="electr_flex">
+      <demands resource="electricity" dispatch="dependent">
+        <capacity>
+          <fixed_value>-1e200</fixed_value>
+        </capacity>
+      </demands>
+      <economics>
+        <lifetime>30</lifetime>
+        <CashFlow name="e_sales" type="repeating" taxable='True' inflation='none' >
+          <driver>
+            <activity>electricity</activity>
+          </driver>
+          <reference_price>
+            <Function method="flex_price">transfers</Function>
+          </reference_price>
+        </CashFlow>
+      </economics>
+    </Component>
+
+  </Components>
+
+  <DataGenerators>
+    <ARMA name='Price' variable="Signal">%HERON_DATA%/TSA/Sine/arma.pk</ARMA>
+    <Function name="transfers">../transfers.py</Function>
+  </DataGenerators>
+
+</HERON>

--- a/tests/integration_tests/mechanics/debug_mode/tests
+++ b/tests/integration_tests/mechanics/debug_mode/tests
@@ -1,25 +1,48 @@
 [Tests]
-  [./DebugMode]
+  [./DebugModeWithSweep]
     type = 'HeronIntegration'
-    input = heron_input.xml
+    input = 'sweep/heron_input.xml'
     [./dispatch_db]
       type = NetCDF
-      output = 'Debug_Run_o/dispatch.nc'
+      output = 'sweep/Debug_Run_o/dispatch.nc'
       gold_files = 'dispatch.nc'
     [../]
     [./dispatch_csv]
       type = UnorderedCSV
-      output = 'Debug_Run_o/dispatch_print.csv'
+      output = 'sweep/Debug_Run_o/dispatch_print.csv'
       gold_files = 'dispatch_print.csv'
       rel_err = 1e-8
     [../]
     [./debug_plot]
       type = Exists
-      output = 'Debug_Run_o/dispatch_id0_y10_c0_f1.png Debug_Run_o/dispatch_id0_y11_c0_f1.png Debug_Run_o/dispatch_id1_y10_c0_f1.png Debug_Run_o/dispatch_id1_y11_c0_f1.png'
+      output = 'sweep/Debug_Run_o/dispatch_id0_y10_c0_f1.png sweep/Debug_Run_o/dispatch_id0_y11_c0_f1.png sweep/Debug_Run_o/dispatch_id1_y10_c0_f1.png sweep/Debug_Run_o/dispatch_id1_y11_c0_f1.png'
     [../]
     [./debug_plot]
       type = Exists
-      output = 'network.png'
+      output = 'sweep/network.png'
+    [../]
+  [../]
+  [./DebugModeWithOpt]
+    type = 'HeronIntegration'
+    input = 'opt/heron_input.xml'
+    [./dispatch_db]
+      type = NetCDF
+      output = 'opt/Debug_Run_o/dispatch.nc'
+      gold_files = 'dispatch.nc'
+    [../]
+    [./dispatch_csv]
+      type = UnorderedCSV
+      output = 'opt/Debug_Run_o/dispatch_print.csv'
+      gold_files = 'dispatch_print.csv'
+      rel_err = 1e-8
+    [../]
+    [./debug_plot]
+      type = Exists
+      output = 'opt/Debug_Run_o/dispatch_id0_y10_c0_f1.png opt/Debug_Run_o/dispatch_id0_y11_c0_f1.png opt/Debug_Run_o/dispatch_id1_y10_c0_f1.png opt/Debug_Run_o/dispatch_id1_y11_c0_f1.png'
+    [../]
+    [./debug_plot]
+      type = Exists
+      output = 'opt/network.png'
     [../]
   [../]
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #381 
Closes #382 

##### What are the significant changes in functionality due to this change request?
For Issues #381:
 - the `outer.xml` template now has two Optimizer nodes (one for Gradient Descent, one for Bayesian Opt), so template driver needs to look at both to remove the `denoises` alias node when using Static Histories

For Issues #382:
- there are two spots in the template driver where a ElementTree parsing or node removal should not be done if `case.get_mode() == 'opt'` AND debug mode is enabled

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

