### PR TITLE
Fixed pathing bug in coverage scripts

### DIFF
--- a/coverage_scripts/check_py_coverage.sh
+++ b/coverage_scripts/check_py_coverage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-SCRIPT_DIRNAME=`dirname $0`
+SCRIPT_DIRNAME=`dirname $(readlink -f "$0")`
 HERON_DIR=`(cd $SCRIPT_DIRNAME/..; pwd)`
 cd $HERON_DIR
 RAVEN_DIR=`python -c 'from src._utils import get_raven_loc; print(get_raven_loc())'`

--- a/coverage_scripts/initialize_coverage.sh
+++ b/coverage_scripts/initialize_coverage.sh
@@ -2,10 +2,11 @@
 
 # This script prepares for running commands from the coverage package
 
-SCRIPT_DIRNAME=`dirname $0`
-HERON_DIR=`(cd $SCRIPT_DIRNAME/..; pwd)`
-echo $HERON_DIR
-cd $HERON_DIR
+if [[ `pwd` != *"HERON" ]]
+then
+    echo "The initialize_coverage.sh script MUST be run from the HERON directory. Please try again."
+    exit
+fi
 RAVEN_DIR=`python -c 'from src._utils import get_raven_loc; print(get_raven_loc())'`
 source $RAVEN_DIR/scripts/establish_conda_env.sh --quiet --load
 RAVEN_LIBS_PATH=`conda env list | awk -v rln="$RAVEN_LIBS_NAME" '$0 ~ rln {print $NF}'`


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#394 

##### What are the significant changes in functionality due to this change request?
This ensures that absolute paths are used in `check_py_coverage.sh` and replaces code with potential to cause errors in `initialize_coverage.sh` with a conditional check to ensure the current directory is as expected.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

