### PR TITLE
Attribute coverage script

### DIFF
--- a/coverage_scripts/attribute_coverage.sh
+++ b/coverage_scripts/attribute_coverage.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This script serves as a wrapper around the check_py_coverage.sh script, running coverage on tests individually
+# and creating a coverage report that records which tests run each line
+
+SCRIPT_DIRNAME=`dirname $(readlink -f "$0")`
+HERON_DIR=`(cd $SCRIPT_DIRNAME/..; pwd)`
+cd $HERON_DIR
+RAVEN_DIR=`python -c 'from src._utils import get_raven_loc; print(get_raven_loc())'`
+
+source $HERON_DIR/coverage_scripts/initialize_coverage.sh
+
+SRC_DIR=`(cd src && pwd)`
+export COVERAGE_RCFILE="$SRC_DIR/../coverage_scripts/.coveragerc"
+
+# Get list of tests on which to run coverage
+GCT_ARGS="--get-all-tests --get-test-names --tests-dir=$HERON_DIR/tests"
+TEST_NAMES_STR=$(cd $RAVEN_DIR/developer_tools; python get_coverage_tests.py $GCT_ARGS)
+IFS=' '
+read -ra TEST_NAMES_ARR <<< "$TEST_NAMES_STR"
+
+coverage erase
+
+TEST_NUM=0
+TEST_TOT=${#TEST_NAMES_ARR[@]}
+for TEST_NAME in "${TEST_NAMES_ARR[@]}"
+do
+  ((TEST_NUM++))
+
+  echo "Running command to check individual test coverage ($TEST_NUM/$TEST_TOT):"
+  echo ./coverage_scripts/check_py_coverage.sh --coverage-run-only --re=\"$TEST_NAME\" --coverage-clargs=\"--context="$TEST_NAME"\"
+  CPC_OUT=$(./coverage_scripts/check_py_coverage.sh --coverage-run-only --re="$TEST_NAME" --coverage-clargs="--context='$TEST_NAME'")
+  if [[ $? -ne 0 ]]
+  then
+    echo "Failure in check_py_coverage run:"
+    echo "$CPC_OUT"
+  fi
+done
+
+coverage combine
+coverage html --show-contexts

--- a/coverage_scripts/attribute_coverage.sh
+++ b/coverage_scripts/attribute_coverage.sh
@@ -28,8 +28,8 @@ do
   ((TEST_NUM++))
 
   echo "Running command to check individual test coverage ($TEST_NUM/$TEST_TOT):"
-  echo ./coverage_scripts/check_py_coverage.sh --coverage-run-only --re=\"$TEST_NAME\" --coverage-clargs=\"--context="$TEST_NAME"\"
-  CPC_OUT=$(./coverage_scripts/check_py_coverage.sh --coverage-run-only --re="$TEST_NAME" --coverage-clargs="--context='$TEST_NAME'")
+  echo ./coverage_scripts/check_py_coverage.sh "$@" --coverage-run-only --re=\"$TEST_NAME\" --coverage-clargs=\"--context="$TEST_NAME"\"
+  CPC_OUT=$(./coverage_scripts/check_py_coverage.sh "$@" --coverage-run-only --re="$TEST_NAME" --coverage-clargs="--context='$TEST_NAME'")
   if [[ $? -ne 0 ]]
   then
     echo "Failure in check_py_coverage run:"

--- a/coverage_scripts/check_py_coverage.sh
+++ b/coverage_scripts/check_py_coverage.sh
@@ -27,6 +27,10 @@ fi # else it's set to a custom string, so leave it
 
 #coverage help run
 SRC_DIR=`(cd src && pwd)`
+if [[ "$SRC_DIR" == "/c/"* ]] # It's a windows path
+then
+  SRC_DIR="C:${SRC_DIR:2}" # coverage.py is picky about this for --source and --omit
+fi
 
 export COVERAGE_RCFILE="$SRC_DIR/../coverage_scripts/.coveragerc"
 SOURCE_DIRS=($SRC_DIR,$SRC_DIR/../templates/)

--- a/coverage_scripts/check_py_coverage.sh
+++ b/coverage_scripts/check_py_coverage.sh
@@ -6,6 +6,25 @@ RAVEN_DIR=`python -c 'from src._utils import get_raven_loc; print(get_raven_loc(
 
 source $HERON_DIR/coverage_scripts/initialize_coverage.sh
 
+# read command-line arguments
+ARGS=()
+for A in "$@"
+do
+  case $A in
+    --re=*)
+      export REGEX="${A#--re=}" # Removes "--re=" and puts regex value into env variable
+      ;;
+    *)
+      ARGS+=("$A")
+      ;;
+  esac
+done
+
+if [[ "$REGEX" == "" ]] # No custom regex value
+then
+  export REGEX="HERON/tests" # Default regex value for run_tests
+fi # else it's set to a custom string, so leave it
+
 #coverage help run
 SRC_DIR=`(cd src && pwd)`
 
@@ -16,7 +35,7 @@ EXTRA="--source=${SOURCE_DIRS[@]} --omit=${OMIT_FILES[@]} --parallel-mode "
 export COVERAGE_FILE=`pwd`/.coverage
 
 coverage erase
-($RAVEN_DIR/run_tests "$@" --re=HERON/tests --python-command="coverage run $EXTRA ")
+($RAVEN_DIR/run_tests "${ARGS[@]}" --re=$REGEX --python-command="coverage run $EXTRA ")
 TESTS_SUCCESS=$?
 
 ## Prepare data and generate the html documents


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#402

##### What are the significant changes in functionality due to this change request?
The main addition is a script that iterates through a list of tests, runs coverage with a regex filter for each individual test, and marks each run with a separate "context", which is shown in the report generated. This script is, admittedly, painfully slow and inefficient, completing a full `check_py_coverage` run for every test; however, the information it seeks to obtain is, on average, unlikely to change greatly in the short term. The current output of this script is the following report: 
[coverage_attribution_report.zip](https://github.com/user-attachments/files/19173754/coverage_attribution_report.zip) (To access report: download, unzip, and open "index" file)

Some changes were also made to the `check_py_coverage.sh` script. These mainly consisted of command line arguments to support `attribute_coverage` and debugging to deal properly with Windows filepaths.

Note: `attribute_coverage` is dependent on `raven.developer_utils.get_coverage_tests.py`. This script was updated with [https://github.com/idaholab/raven/pull/2431](url) to support `attribute_coverage`. Future faulty output from `attribute_coverage` could be due to `get_coverage_tests` becoming outdated.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

