### PR TITLE
Catch errors resulting from duplicated variable names

### DIFF
--- a/src/input_loader.py
+++ b/src/input_loader.py
@@ -85,7 +85,6 @@ def parse(xml, loc, messageHandler):
   # Check for duplicated variable names in the sources
   source_var_names = {source.name: source.get_variable() or [] for source in sources}
   name_counts = Counter(it.chain.from_iterable(source_var_names.values()))
-  print(f"{name_counts}")
   if duplicated := dict(filter(lambda x: x[1] > 1, name_counts.items())):
     raise ValueError(f"Multiple sources in <DataGenerators> node specify values for variables {list(duplicated.keys())}")
 

--- a/src/input_loader.py
+++ b/src/input_loader.py
@@ -5,12 +5,12 @@
   Parses an input file, returning the objects therein.
 """
 import sys
-import xml.etree.ElementTree as ET
+import itertools as it
+from collections import Counter
 
 from . import Cases
 from . import Components
 from . import Placeholders
-from . import ValuedParams
 
 from . import _utils as hutils
 try:
@@ -81,6 +81,13 @@ def parse(xml, loc, messageHandler):
       raise IOError(f'Unrecognized DataGenerator: {sub_xml.tag}')
     new.read_input(sub_xml)
     sources.append(new)
+
+  # Check for duplicated variable names in the sources
+  source_var_names = {source.name: source.get_variable() or [] for source in sources}
+  name_counts = Counter(it.chain.from_iterable(source_var_names.values()))
+  print(f"{name_counts}")
+  if duplicated := dict(filter(lambda x: x[1] > 1, name_counts.items())):
+    raise ValueError(f"Multiple sources in <DataGenerators> node specify values for variables {list(duplicated.keys())}")
 
   # now go back through and link up stuff
   for comp in components:

--- a/tests/integration_tests/mechanics/unique_var_names/heron_input.xml
+++ b/tests/integration_tests/mechanics/unique_var_names/heron_input.xml
@@ -1,0 +1,49 @@
+<HERON>
+  <TestInfo>
+    <name>UniqueVarNames</name>
+    <author>j-bryan</author>
+    <created>2025-06-04</created>
+    <description>
+      Tests for an error being thrown when DataGenerator items specify the same variable name
+    </description>
+    <classesTested>HERON</classesTested>
+  </TestInfo>
+
+    <Case name="Runs">
+      <mode>sweep</mode>
+      <num_arma_samples>3</num_arma_samples>
+      <time_discretization>
+        <time_variable>Time</time_variable>
+        <end_time>2</end_time>
+        <num_steps>21</num_steps>
+      </time_discretization>
+      <economics>
+        <ProjectTime>3</ProjectTime>
+        <DiscountRate>0.08</DiscountRate>
+        <tax>0.0</tax>
+        <inflation>0.03</inflation>
+        <verbosity>50</verbosity>
+      </economics>
+      <dispatcher>
+        <pyomo/>
+      </dispatcher>
+    </Case>
+
+    <Components>
+      <Component name="source">
+        <produces resource="a" dispatch="fixed">
+          <capacity resource="a">
+            <sweep_values>1, 2</sweep_values>
+          </capacity>
+        </produces>
+        <economics>
+          <lifetime>10</lifetime>
+        </economics>
+      </Component>
+    </Components>
+
+    <DataGenerators>
+      <CSV name='flex' variable="Signal">%HERON_DATA%/mechanics/static_history/Static.csv</CSV>
+      <CSV name='flex_alt' variable="Signal">%HERON_DATA%/mechanics/static_history/Static.csv</CSV>
+    </DataGenerators>
+</HERON>

--- a/tests/integration_tests/mechanics/unique_var_names/tests
+++ b/tests/integration_tests/mechanics/unique_var_names/tests
@@ -1,0 +1,7 @@
+[Tests]
+  [./UniqueVarNames]
+    type = HeronIntegration
+    input = heron_input.xml
+    expected_fail = true
+  [../]
+[]


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#407 

##### What are the significant changes in functionality due to this change request?
Disallows using duplicate variable names in DataGenerator sources. This catches bugs which otherwise would've produced erroneous results due to one variable overwriting another in RAVEN workflow.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [x] 4. Automated Tests should pass.
- [x] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [x] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

