### PR TITLE
Print statements, npv_exempt cash flows, dispatch plot fixes

### DIFF
--- a/src/Cases.py
+++ b/src/Cases.py
@@ -281,10 +281,12 @@ class Case(Base):
     debug.addSub(InputData.parameterInputFactory('macro_steps', contentType=InputTypes.IntegerType,
         descr=r"""sets the number of macro steps (e.g. years) the stochastic synthetic histories and dispatch
               optimization should include. \default{1}"""))
-    debug.addSub(InputData.parameterInputFactory('dispatch_plot', contentType=InputTypes.BoolType,
+    dispatch_plot = InputData.parameterInputFactory('dispatch_plot', contentType=InputTypes.BoolType,
         descr=r"""provides a dispatch plot after running through \xmlNode{inner_samples} and
               \xmlNode{macro_steps} provided. To prevent plotting output during debug mode set to "False".
-              \default{True}"""))
+              \default{True}""")
+    dispatch_plot.addParam('sep_by_resource', param_type=InputTypes.BoolType, descr=r"""produce one figure per resource. \default{False}""")
+    debug.addSub(dispatch_plot)
     debug.addSub(InputData.parameterInputFactory('cashflow_plot', contentType=InputTypes.BoolType,
         descr=r"""provides a cashflow plot after running through \xmlNode{inner_samples} and
               \xmlNode{macro_steps} provided. To prevent plotting output during debug mode set to "False".
@@ -656,6 +658,7 @@ class Case(Base):
         'inner_samples': 1,            # how many inner realizations to sample
         'macro_steps': 1,              # how many "years" for inner realizations
         'dispatch_plot': True,         # whether to output a dispatch plot in debug mode
+        'disp_plot_sep': False,        # whether to separate dispatch plots into one figure per resource
         'cashflow_plot': True          # whether to output a cashflow plot in debug mode
     }
 
@@ -694,6 +697,8 @@ class Case(Base):
         self.debug['enabled'] = True
         for node in item.subparts:
           self.debug[node.getName()] = node.value
+          if node.getName() == 'dispatch_plot':
+            self.debug['disp_plot_sep'] = node.parameterValues.get('sep_by_resource', False)
       elif item.getName() == 'label':
         self._labels[item.parameterValues['name']] = item.value
       if item.getName() == 'verbosity':

--- a/src/DispatchManager.py
+++ b/src/DispatchManager.py
@@ -571,10 +571,8 @@ class DispatchRunner:
       specific_meta['HERON']['all_activity'] = dispatch
       specific_activity = {}
       final_cashflows = final_comp.getCashflows()
-      for f, heron_cf in enumerate(comp.get_cashflows()):
+      for f, heron_cf in enumerate(filter(lambda cf: not cf.is_npv_exempt(), comp.get_cashflows())):
         # get the corresponding TEAL.CashFlow
-        if heron_cf.is_npv_exempt():
-          continue # Skip adding this cashflow to the final cashflows
         teal_cf = teal_comp.getCashflows()[f]
         final_cf = final_cashflows[f]
         # sanity continued

--- a/src/DispatchPlot.py
+++ b/src/DispatchPlot.py
@@ -49,6 +49,7 @@ class DispatchPlot(PlotPlugin):
     specs.addSub(InputData.parameterInputFactory('macro_variable', contentType=InputTypes.StringType))
     specs.addSub(InputData.parameterInputFactory('micro_variable', contentType=InputTypes.StringType))
     specs.addSub(InputData.parameterInputFactory('signals', contentType=InputTypes.StringListType))
+    specs.addSub(InputData.parameterInputFactory('sep_by_resource', contentType=InputTypes.BoolType))
     return specs
 
   def __init__(self):
@@ -63,6 +64,7 @@ class DispatchPlot(PlotPlugin):
     self._source = None
     self._macroName = None
     self._microName = None
+    self._sepByResource = False
     self._addSignals = []
 
   def handleInput(self, spec):
@@ -81,6 +83,8 @@ class DispatchPlot(PlotPlugin):
         self._microName = node.value
       elif node.getName() == 'signals':
         self._addSignals = node.value
+      elif node.getName() == 'sep_by_resource':
+        self._sepByResource = node.value
 
   def initialize(self, stepEntities):
     """
@@ -329,10 +333,19 @@ class DispatchPlot(PlotPlugin):
       # nature of the subplots, as well as the dynamic number of
       # components and signals to plot (i.e. dynamically nested subplots)
 
-      # If only 3 resources, make one figure; otherwise, 2 resources per figure
-      if len(resources) <= 3:
+      # Use a separate figure for each resource, if requested.
+      if self._sepByResource:
+        res_figs = []
+        res_axs = []
+        for _ in range(len(resources)):
+          fig, axs = plt.subplots()
+          res_figs.append(fig)
+          res_axs.append(axs)
+      # Otherwise, if only 3 resources, make one figure
+      elif len(resources) <= 3:
         fig, res_axs = plt.subplots(len(resources), 1, sharex=True, squeeze=False)
         res_figs = [fig]
+      # Otherwise if more than 3 resources, plot 2 resources per figure
       else:
         res_figs = []
         res_axs = []

--- a/templates/bilevel_templates.py
+++ b/templates/bilevel_templates.py
@@ -99,25 +99,22 @@ class BilevelTemplate(RavenTemplate):
 
     return {"inner": self.inner.template_xml, "outer": self.outer.template_xml}
 
-  def writeWorkflow(self, template: dict[str, ET.Element], destination: dict[str, str], run: bool = False) -> None:
+  def writeWorkflow(self, dest_dir: str) -> None:
     """
       Writes a template to file.
-      @ In, template, dict[str, ET.Element], XML trees to write
-      @ In, destination, dict[str, str], paths to write the templates to
-      @ In, run, bool, optional, if True then run the workflow after writing? good idea?
-      @ Out, errors, int, 0 if successfully wrote [and run] and nonzero if there was a problem
+      @ In, dest_dir, str, path to the directory to which to write template workflows
+      @ Out, None
     """
-    for name, xml in template.items():
-      super().writeWorkflow(xml, destination[name], run)
+    self.inner.writeWorkflow(dest_dir)
+    self.outer.writeWorkflow(dest_dir)
 
     # copy "write_inner.py", which has the denoising and capacity fixing algorithms
     conv_filename = "write_inner.py"
     write_inner_dir = Path(__file__).parent
-    dest_dir = Path(next(iter(destination.values()))).parent
     conv_src = write_inner_dir / conv_filename
-    conv_file = dest_dir / conv_filename
+    conv_file = Path(dest_dir) / conv_filename
     shutil.copyfile(str(conv_src), str(conv_file))
-    print(f"Wrote '{conv_filename}' to '{destination}'")
+    print(f"Wrote '{conv_filename}' to '{str(conv_file)}'")
 
   @property
   def template_xml(self) -> dict[str, ET.Element]:

--- a/templates/debug_template.py
+++ b/templates/debug_template.py
@@ -268,6 +268,7 @@ class DebugTemplate(RavenTemplate):
     disp_plot.macro_variable = case.get_year_name()
     disp_plot.micro_variable = case.get_time_name()
     disp_plot.signals.append("GRO_debug_synthetics")
+    disp_plot.sep_by_resource = case.debug["disp_plot_sep"]
     return disp_plot
 
   def _make_cashflow_plot(self) -> TealCashFlowPlot:

--- a/templates/raven_template.py
+++ b/templates/raven_template.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import itertools as it
 import xml.etree.ElementTree as ET
 
-from .imports import xmlUtils, Template
+from .imports import Template
 from .heron_types import HeronCase, Component, Source, ValuedParam
 from .naming_utils import get_result_stats, get_component_activity_vars, get_opt_objective, get_statistics, Statistic
 from .xml_utils import add_node_to_tree, stringify_node_values
@@ -26,7 +26,7 @@ from .snippets.optimizers import BayesianOptimizer, GradientDescent
 from .snippets.models import GaussianProcessRegressor, PickledROM, EnsembleModel
 from .snippets.distributions import Distribution, Uniform
 from .snippets.outstreams import PrintOutStream
-from .snippets.dataobjects import DataObject, PointSet, DataSet
+from .snippets.dataobjects import PointSet, DataSet
 from .snippets.variablegroups import VariableGroup
 from .snippets.files import File
 from .snippets.factory import factory as snippet_factory
@@ -118,27 +118,26 @@ class RavenTemplate(Template):
     # Universal workflow settings
     self._set_verbosity(kwargs["case"].get_verbosity())
 
-  def writeWorkflow(self, template: ET.Element, destination: str, run: bool = False) -> None:
+  def writeWorkflow(self, dest_dir: str) -> None:
     """
       Writes a template to file.
-      @ In, template, xml.etree.ElementTree.Element, file to write
-      @ In, destination, str, path and filename to write to
-      @ In, run, bool, optional, if True then run the workflow after writing? good idea?
-      @ Out, errors, int, 0 if successfully wrote [and run] and nonzero if there was a problem
+      @ In, dest_dir, str, path to the directory to which to write template workflows
+      @ Out, None
     """
     # Ensure all node attribute values and text are expressed as strings. Errors are thrown if any of these aren't
     # strings. Enforcing this here allows flexibility with how node values are stored and manipulated before write
     # time, such as storing values as lists or numeric types. For example, text fields which are a comma-separated
     # list of values can be stored in the RavenSnippet object as a list, and new items can be inserted into that
     # list as needed, then the list can be converted to a string only now at write time.
-    stringify_node_values(template)
+    stringify_node_values(self._template)
 
     # Remove any unused top-level nodes (Models, Samplers, etc.) to keep things looking clean
-    for node in template:
+    for node in self._template:
       if len(node) == 0:
-        template.remove(node)
+        self._template.remove(node)
 
-    super().writeWorkflow(template, destination, run)
+    destination = self.get_write_path(dest_dir)
+    super().writeWorkflow(self._template, destination)
     print(f"Wrote '{self.write_name}' to '{destination}'")
 
   @property
@@ -221,7 +220,7 @@ class RavenTemplate(Template):
     @ In, name, str, case name to use
     @ Out, None
     """
-    run_info = self._template.find("RunInfo")  # type: RunInfo
+    run_info: RunInfo = self._template.find("RunInfo")
     run_info.job_name = name
     run_info.working_dir = name
 
@@ -232,7 +231,7 @@ class RavenTemplate(Template):
     @ In, index, int, optional, the index to add the step at
     @ Out, None
     """
-    run_info = self._template.find("RunInfo")  # type: RunInfo
+    run_info: RunInfo = self._template.find("RunInfo")
     idx = index if index is not None else len(run_info.sequence)
     run_info.sequence.insert(idx, step)
 
@@ -264,7 +263,7 @@ class RavenTemplate(Template):
     @ Out, step, IOStep, the step used to do the loading
     """
     # Get the file to load. Might already exist in the template XML
-    file = self._template.find("Files/Input[@name='{source.name}']")  # type: File
+    file: File | None = self._template.find("Files/Input[@name='{source.name}']")
     if file is None:
       file = File(source.name)
       file.path = source._target_file
@@ -416,14 +415,14 @@ class RavenTemplate(Template):
     @ In, sources, list[Source], case sources
     @ Out, None
     """
-    dispatch_eval = self._template.find("DataObjects/DataSet[@name='dispatch_eval']")  # type: DataSet
+    dispatch_eval: DataSet = self._template.find("DataObjects/DataSet[@name='dispatch_eval']")
 
     # Gather any ARMA sources from the list of sources
     arma_sources = [s for s in sources if s.is_type("ARMA")]
 
     # Add cluster index info to dispatch variable groups and data objects
     if any(source.eval_mode == "clustered" for source in arma_sources):
-      vg_dispatch = self._template.find("VariableGroups/Group[@name='GRO_dispatch']")  # type: VariableGroup
+      vg_dispatch: VariableGroup = self._template.find("VariableGroups/Group[@name='GRO_dispatch']")
       vg_dispatch.variables.append(self.namingTemplates["cluster_index"])
       dispatch_eval.add_index(self.namingTemplates["cluster_index"], "GRO_dispatch_in_Time")
 
@@ -555,7 +554,7 @@ class RavenTemplate(Template):
           dist_name = self.namingTemplates["distribution"].format(variable=feat_name)
 
           # Reconstruct distribution XML node from valuedParam definition
-          dist_node = vp._vp.get_distribution()  # type: ET.Element
+          dist_node: ET.Element = vp._vp.get_distribution()
           dist_node.set("name", dist_name)
           dist_snippet = snippet_factory.from_xml(dist_node)
           distributions.append(dist_snippet)
@@ -597,7 +596,7 @@ class RavenTemplate(Template):
       interaction = component.get_interaction()
       name = component.name
       var_name = self.namingTemplates["variable"].format(unit=name, feature="capacity")
-      cap = interaction.get_capacity(None, raw=True)  # type: ValuedParam
+      cap: ValuedParam = interaction.get_capacity(None, raw=True)
 
       if not cap.is_parametric():  # we already know the value
         continue
@@ -640,7 +639,7 @@ class RavenTemplate(Template):
     if case.debug["enabled"]:
       indices.append(cluster_index)
 
-    time_series_vargroup = self._template.find("VariableGroups/Group[@name='GRO_timeseries']")  # type: VariableGroup
+    time_series_vargroup: VariableGroup = self._template.find("VariableGroups/Group[@name='GRO_timeseries']")
 
     for source in filter(lambda x: x.is_type("CSV"), sources):
       # Add the source variables to the GRO_timeseries_in variable group

--- a/templates/snippets/outstreams.py
+++ b/templates/snippets/outstreams.py
@@ -162,8 +162,18 @@ class HeronDispatchPlot(OutStream):
     @ In, None
     @ Out, sep, bool, separate plots for each resource
     """
+    # "True" conditions
+    #   - node present and text is None
+    #   - node present and text is True
+    # "False" conditions
+    #   - node not present
+    #   - node present and text is False
     node = self.find("sep_by_resource")
-    sep = False if node is None else bool(node.text)
+    # Need to be careful with falsy condition since bool(None) == False
+    if node is None or (not bool(node.text) and node.text is not None):
+      sep = False
+    else:
+      sep = True
     return sep
 
   @sep_by_resource.setter

--- a/templates/snippets/outstreams.py
+++ b/templates/snippets/outstreams.py
@@ -155,6 +155,25 @@ class HeronDispatchPlot(OutStream):
     """
     find_node(self, "signals").text = value
 
+  @property
+  def sep_by_resource(self) -> bool:
+    """
+    Getter for sep_by_resource node
+    @ In, None
+    @ Out, sep, bool, separate plots for each resource
+    """
+    node = self.find("sep_by_resource")
+    sep = False if node is None else bool(node.text)
+    return sep
+
+  @sep_by_resource.setter
+  def sep_by_resource(self, value: bool):
+    """
+    Setting for sep_by_resource node
+    @ In, value, bool, separate plots for each resource
+    @ Out, None
+    """
+    find_node(self, "sep_by_resource").text = value
 
 class TealCashFlowPlot(OutStream):
   """ OutStream snippet for TEAL cashflow plots """

--- a/templates/template_driver.py
+++ b/templates/template_driver.py
@@ -88,15 +88,14 @@ class TemplateDriver(Base):
     print("========================")
     print("HERON: writing files ...")
     print("========================")
-    dest = self.template.get_write_path(dest_dir)
-    self.template.writeWorkflow(self.template.template_xml, dest)
+    self.template.writeWorkflow(dest_dir)
 
     # Write library of info so it can be read in dispatch during inner run. Doing this here ensures that the lib file
     # is written just once, no matter the number of workflow files written by the template.
     lib_file = Path(dest_dir) / self.template.namingTemplates["lib file"]
     with lib_file.open("wb") as lib:
       pk.dump((case, components, sources), lib)
-    print(f"Wrote '{lib_file.name}' to '{str(lib_file.resolve())}'")
+    print(f"Wrote '{lib_file.name}' to '{str(lib_file)}'")
 
   ###################
   # Utility methods #

--- a/tests/integration_tests/mechanics/debug_mode/sweep/heron_input.xml
+++ b/tests/integration_tests/mechanics/debug_mode/sweep/heron_input.xml
@@ -15,7 +15,7 @@
     <debug>
       <inner_samples>2</inner_samples>
       <macro_steps>2</macro_steps>
-      <dispatch_plot>True</dispatch_plot>
+      <dispatch_plot sep_by_resource="True">True</dispatch_plot>
     </debug>
     <num_arma_samples>1</num_arma_samples>
     <time_discretization>

--- a/tests/integration_tests/mechanics/npv_exempt/heron_input.xml
+++ b/tests/integration_tests/mechanics/npv_exempt/heron_input.xml
@@ -4,15 +4,15 @@
     <author>dylanjm</author>
     <created>2024-03-26</created>
     <description>
-      Tests NPV exempt Cashflows. This is a recreation of the Cashflows test from 
+      Tests NPV exempt Cashflows. This is a recreation of the Cashflows test from
       the HERON test suite. The only difference is the Variable Operating and Maitenance
-      Costs (VOM) cashflow is now NPV exempt. The Excel File 'analytic.xlsx' shows 
-      the expected results. When the NPV exemption is turned on, the mean NPV for 
+      Costs (VOM) cashflow is now NPV exempt. The Excel File 'analytic.xlsx' shows
+      the expected results. When the NPV exemption is turned on, the mean NPV for
       both sweep values (1, 2) should be: $5,373.37 and $10,748.27 respectively.
-      When NPV exemption is turned off (i.e. the Cashflows test) the results for 
+      When NPV exemption is turned off (i.e. the Cashflows test) the results for
       both sweep values should be $5,218.73 and $10,439.00 respectively. We can see
       that having the VOM cashflow NPV exempt increases the mean NPV in both cases
-      since VOM is a cost and is left out of the NPV calculation.                                        
+      since VOM is a cost and is left out of the NPV calculation.
     </description>
     <classesTested>HERON</classesTested>
   </TestInfo>
@@ -62,6 +62,14 @@
             </scaling_factor_x>
           <!--  <depreciate>5</depreciate> -->
           </CashFlow>
+          <CashFlow name="VOM" type="repeating" taxable="True" inflation="none" npv_exempt="True">
+            <driver>
+              <activity>a</activity>
+            </driver>
+            <reference_price>
+              <fixed_value>-1</fixed_value>
+            </reference_price>
+          </CashFlow>
           <CashFlow name="FOM" type="repeating" period='year' taxable="False" inflation="none">
             <driver>
               <variable>source_capacity</variable>
@@ -76,14 +84,6 @@
             <scaling_factor_x>
               <fixed_value>0.999</fixed_value>
             </scaling_factor_x>
-          </CashFlow>
-          <CashFlow name="VOM" type="repeating" taxable="True" inflation="none" npv_exempt="True">
-            <driver>
-              <activity>a</activity>
-            </driver>
-            <reference_price>
-              <fixed_value>-1</fixed_value>
-            </reference_price>
           </CashFlow>
         </economics>
       </Component>

--- a/tests/unit_tests/snippets/test_outstreams.py
+++ b/tests/unit_tests/snippets/test_outstreams.py
@@ -178,6 +178,37 @@ class TestHeronDispatchPlot(unittest.TestCase, TestOutStreamBase):
     self.assertListEqual(self.outstream.signals, ["inp1"])
     self.assertListEqual(self.outstream.find("signals").text, ["inp1"])
 
+  def test_sep_by_resource(self):
+    """
+    Test sep_by_resource property
+    @ In, None
+    @ Out, None
+    """
+    # "sep_by_resource" node is not required and is not present by default
+    node = self.outstream.find("sep_by_resource")
+    self.assertIsNone(node)
+
+    # Setting the sep_by_resource property to true ensures the node is present and the node value (text) is True
+    self.outstream.sep_by_resource = True
+    self.assertTrue(self.outstream.sep_by_resource)
+    node = self.outstream.find("sep_by_resource")
+    self.assertIsNotNone(node)
+    self.assertTrue(node.text)
+
+    # A node with no text should also evaluate to True
+    node = self.outstream.find("sep_by_resource")
+    node.text = None
+    self.assertTrue(self.outstream.sep_by_resource)
+
+    # property returns False if node not present or if node value is False
+    self.outstream.remove(node)
+    self.assertFalse(self.outstream.sep_by_resource)
+    self.outstream.sep_by_resource = False
+    node = self.outstream.find("sep_by_resource")
+    self.assertIsNotNone(node)
+    self.assertFalse(node.text)
+    self.assertFalse(self.outstream.sep_by_resource)
+
 
 class TestTealCashFlowPlot(unittest.TestCase, TestOutStreamBase):
   """ TealCashFlowPlot snippet tests """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#408
#410 

##### What are the significant changes in functionality due to this change request?
- Fixes print statements when writing bilevel workflows (#408)
- Allows for CashFlow nodes with `npv_exempt="True"` to be specified in any order with other cash flows (#410)
- Adds an option to dispatch plots to use one figure per resource. This can help with readability of the dispatch plots when multiple resources are used, particularly for workflows with many components. This is an optional behavior, and the original strategy of up to 3 resources per figure is retained.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/HERON/wiki/Code-Standards) for details.
- [ ] 4. Automated Tests should pass.
- [ ] 5. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large tes.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added, the the analytic documentation must be updated/added.
- [ ] 9. If any test used as a basis for documentation examples have been changed, the associated documentation must be reviewed and assured the text matches the example.

